### PR TITLE
fix: guard missing $character when creating a NonChar application

### DIFF
--- a/AppDetails.php
+++ b/AppDetails.php
@@ -215,6 +215,7 @@ if( $mode == 'doAdd' || $mode == 'doEdit' ) {
 	}
 	$app_info->organization = $organizationDAO->readByID( $app_info->org_id );
 
+	$character = null;
 	if( is_numeric( $app_info->character_id ) && $app_info->character_id != 0 ) {
 		$character = $characterDAO->readByID( $app_info->character_id );
 	}
@@ -248,18 +249,20 @@ if( $mode == 'doAdd' || $mode == 'doEdit' ) {
 		$app_info->user_id = $app_info->character->user_id;
 	else
 		$app_info->user_id = $_SESSION['user_id'];
-	$app_info->venue_id = $character->venue_id ;
+	$app_info->venue_id = is_object( $character ) ? $character->venue_id : 0;
 	$app_info->required_approval = "High";
 	$app_info->status = "Pending Low";
 	$app_info->justification = $ThisJustificationBlock;
 	$app_info->active = 1;
-	$app_info->character_sheet = $character->character_sheet;
+	$app_info->character_sheet = is_object( $character ) ? $character->character_sheet : "";
 	$app_info->creation_date = time();
 	$app_info->status_change_date = time();
 	$app_info->update_date = time();
 	$app_info->venue = $venueDAO->readByID( $app_info->venue_id );
-	$character->venue = $venueDAO->readByID( $character->venue_id);
-	$app_info->character = $character;
+	if( is_object( $character ) ) {
+		$character->venue = $venueDAO->readByID( $character->venue_id );
+		$app_info->character = $character;
+	}
 
 } else if( $mode == 'edit' ) {
 	if ( isset( $_POST['approve'] ) ) {


### PR DESCRIPTION
## Problem

Creating a non-character ("VSS or Plotline") application via
`AppDetails.php?char_id=NonChar&mode=add&` returns a 500 on the live legacy site (PHP 8.3).

Captured in `/var/log/nginx/legacy_error.log`:

```
PHP Warning: Undefined variable $character in AppDetails.php on lines 239, 251, 256, 261
PHP Warning: Attempt to read property "venue_id" on null on lines 251, 261
PHP Warning: Attempt to read property "character_sheet" on null on line 256
PHP Fatal error: Uncaught Error: Attempt to assign property "venue" on null
              in AppDetails.php:261
```

## Root cause

In the `mode == 'add'` block, the local `$character` variable is only assigned when
`character_id` is numeric. For `char_id=NonChar` it stays undefined/null, but the code then
reads `$character->venue_id` / `$character->character_sheet` and assigns
`$character->venue = ...` — the last of which is a fatal Error on PHP 8.x (assigning a
property on null). `$app_info->character` was already guarded for `user_id`, but the
separate `$character` used for venue/character_sheet was not.

## Fix

- Initialize `$character = null;` before the numeric guard (removes the undefined-variable
  warnings).
- Guard the character-derived assignments with `is_object($character)`:
  - `venue_id` falls back to `0` (→ venue renders "N/A")
  - `character_sheet` falls back to `""`
  - skip `$character->venue` / `$app_info->character` reassignment when there is no character
    (it stays null → renders "VSS or Plotline")

Display templates (`AppDetailsTopSection.html`) already handle null venue/character, so no
template changes are needed. Behavior for real (numeric) characters is unchanged.

## Testing

- `php -l AppDetails.php` — no syntax errors.
- Manual: with the fix, the new-application form for `char_id=NonChar&mode=add` renders
  (venue "N/A", "VSS or Plotline") instead of 500; legacy error log shows no new
  `$character` warnings or fatal. (No automated test suite exists in this repo.)
