### PR TITLE
fix: PHP 8 fatal + warnings in XP/character pages

### DIFF
--- a/ModifyCharacterListAddCharacter.php
+++ b/ModifyCharacterListAddCharacter.php
@@ -8,6 +8,12 @@ $character->venue_id = $_POST["venue"];
 $character->subtype = $_POST["SubType"];
 $character->active = 1;
 
+// Defaults so the redirect logic below never reads undefined values.
+// $vss_npc / $org_npc are only set in the NPC branch; $redirect may be absent.
+$vss_npc = 0;
+$org_npc = 0;
+$redirect = $_POST["redirect"] ?? "";
+
 if ( preg_match( "/NPC:(-?\d+)/", $_POST["Type"], $matches ) ) {
 	$npc_id = $matches[1];
 	$character->user_id = 0;
@@ -44,14 +50,14 @@ if ( $_POST["name"]=="" ) {
 
 if( $characterDAO->create( $character ) ) {
 	$max_id=$character->id;
-	if ( $_POST["redirect"]=="AppDetails" ) {
+	if ( $redirect=="AppDetails" ) {
 		header( "Location: AppDetails.php?mode=add&char_id=$max_id&appUser_id=$thisuser_id&" );
 	}	elseif( $vss_npc ) {
  		header("Location: ModifyVSSCharacterList1.php");
 	} elseif ( $org_npc ) {
  		header("Location: app_main.php");
 	} else {
- 		header("Location: MoveCharacter.php?char_id=$max_id&redirect=$_POST[redirect]");
+ 		header("Location: MoveCharacter.php?char_id=$max_id&redirect=$redirect");
 	}
 } else {
 	header( "Location: AddCharacter.php?errmsg=1&" );

--- a/ModifyCharacterXPList1.php
+++ b/ModifyCharacterXPList1.php
@@ -28,6 +28,9 @@ notes - text/varchar
 	$spentsort= ( isset($_GET["spentsort"]) ? $_GET["spentsort"] : "spentdate");
 	$earnedinverted= ( isset($_GET["earnedinverted"]) ? 1 : 0);
 	$spentinverted= ( isset($_GET["spentinverted"]) ? 1 : 0);
+	// CSS class applied to the active sort-column header (never assigned a value
+	// historically); default to empty so the header markup emits no undefined-variable warning.
+	$cellclass = "";
 	if ( $earnedsort=="earneddate" xor $earnedinverted ) {
 		$earneddirection="desc";
 	} else {

--- a/ModifyCharacterXPList2.php
+++ b/ModifyCharacterXPList2.php
@@ -1,7 +1,7 @@
 <?php
   include_once("db.inc");
 
-	$modify = $_POST["modify"];
+	$modify = $_POST["modify"] ?? "";
 
 	if ( $_POST["xptype"]=="earned" ) {
 		$thistable="earnedxp";

--- a/ModifyCharacterXPList4.php
+++ b/ModifyCharacterXPList4.php
@@ -11,11 +11,11 @@
 		"notes=? ".
 		"where id=?";
 	$params = [
-		$_POST[eventname],
+		$_POST["eventname"],
 		$mysqldate,
-		$_POST[xpearned],
-		$_POST[notes],
-		$_POST[id]
+		$_POST["xpearned"],
+		$_POST["notes"],
+		$_POST["id"]
 	];
   } else {
   	$datestamp = strtotime( stripslashes( $_POST["spentdate"] ) );
@@ -27,11 +27,11 @@
 		"notes=? ".
 		"where id=?";
 	$params = [
-		$_POST[itembought],
+		$_POST["itembought"],
 		$mysqldate,
-		$_POST[xpspent],
-		$_POST[notes],
-		$_POST[id]
+		$_POST["xpspent"],
+		$_POST["notes"],
+		$_POST["id"]
 	];
   }
 


### PR DESCRIPTION
## Problem

A scan of the retained nginx error logs (after fixing the AppDetails NonChar fatal) surfaced
more PHP 8 issues on the legacy site (`approvals_rewrite`):

- **Fatal:** `ModifyCharacterXPList4.php` → `Uncaught Error: Undefined constant "eventname"`.
  It uses **bareword** `$_POST` array keys (`$_POST[eventname]`, `$_POST[xpearned]`, …). On
  PHP 8 a bareword is an undefined constant → fatal, which **silently breaks saving edits to
  an XP entry** (the page returns ~blank and the UPDATE never runs).
- **Warnings** (non-fatal, but noisy / latent): undefined `$vss_npc`/`$org_npc` and an
  unguarded `$_POST["redirect"]` in `ModifyCharacterListAddCharacter.php`; undefined
  `$cellclass` in `ModifyCharacterXPList1.php`; unguarded `$_POST["modify"]` in
  `ModifyCharacterXPList2.php`.

## Fix

- `ModifyCharacterXPList4.php`: quote the bareword `$_POST` keys (both the earnedxp and
  spentxp branches). Its insert-sibling `ModifyCharacterXPListAddXP.php` already used quoted
  keys, so the fatal was isolated to this file.
- `ModifyCharacterListAddCharacter.php`: initialize `$vss_npc`/`$org_npc` (previously only set
  in the NPC branch) and read `$_POST["redirect"]` via a guarded `$redirect` local used in the
  post-create redirect logic.
- `ModifyCharacterXPList1.php`: initialize `$cellclass` (read in the sort-column header but
  never assigned).
- `ModifyCharacterXPList2.php`: null-coalesce guard on `$_POST["modify"]`.

No behavior change for valid input — this only removes the fatal and the
undefined-variable/array-key warnings.

## Testing

- `php -l` clean on all four files.
- Manual: edit/save an earned and a spent XP entry (`ModifyCharacterXPList3 → XPList4`) and
  confirm it now persists with no `Undefined constant` fatal in `legacy_error.log`; exercise
  add-character + XP list pages and confirm the warnings are gone. (No automated test suite in
  this repo.)
