### PR TITLE
fix: guard undefined $_GET['redirect'] in MoveCharacter.php

### DIFF
--- a/MoveCharacter.php
+++ b/MoveCharacter.php
@@ -68,7 +68,7 @@
 </div>
 <form action="MoveCharacter2.php" method="post">
 <input type="hidden" name="char_id" value="<?php echo $char_id?>">
-<input type="hidden" name="redirect" value="<?php echo $_GET['redirect']?>">
+<input type="hidden" name="redirect" value="<?php echo $_GET['redirect'] ?? ''?>">
 <input type="hidden" name="user_id" value="<?php echo $character->user_id?>">
 <table class="data">
 	<tr>


### PR DESCRIPTION
Removes the last PHP 8 warning surfaced in the 24h health check: `Undefined array key "redirect" in MoveCharacter.php on line 71`.

MoveCharacter.php line 71 echoed `$_GET['redirect']` into a hidden form field without a guard, so opening the page without a `redirect` query param logged a warning. Guarded with `?? ''`; behavior is unchanged when the param is present (it was already treated as empty when absent). Same PHP-8 undefined-key family already fixed in ModifyCharacterListAddCharacter.php / ModifyCharacterXPList2.php.

Testing: `php -l` clean; verify no new MoveCharacter.php `redirect` warning in legacy_error.log after deploy. No automated test suite in this repo.