### PR TITLE
feat: sync organizations to the Google map Sheet + clean org-name mojibake

### DIFF
--- a/ModifyOrgList2.php
+++ b/ModifyOrgList2.php
@@ -6,6 +6,9 @@
   	$placeholders = implode(",", array_fill(0, count($delete_ids), "?"));
   	$query="delete from organizations where id in ($placeholders)";
     $db->query($query, $delete_ids);
+    // Keep the public map's Google Sheet in sync (best-effort; never blocks the delete).
+    include_once("classes/GoogleSheetsService.php");
+    GoogleSheetsService::syncOrgMap();
     header("Location: ModifyOrgList1.php");
 		exit();
 	} else if ( !empty($_POST["modify"]))  {

--- a/ModifyOrgList4.php
+++ b/ModifyOrgList4.php
@@ -32,9 +32,9 @@
 	$params = [
     		$_POST['nation'],
     		$_POST['region'],
-    		$_POST['domain'],
+    		trim($_POST['domain']),
     		$_POST['chapter'],
-    		$_POST['orgName'],
+    		trim($_POST['orgName']),
     		$_POST['city'],
     		$_POST['state'],
     		$_POST['country'],
@@ -46,6 +46,9 @@
     	];
   	$db->query($query, $params);
   }
+  // Keep the public map's Google Sheet in sync (best-effort; never blocks the save).
+  include_once("classes/GoogleSheetsService.php");
+  GoogleSheetsService::syncOrgMap();
   header("Location: ModifyOrgList1.php");
   
 ?>

--- a/ModifyOrgListAddOrg.php
+++ b/ModifyOrgListAddOrg.php
@@ -13,14 +13,18 @@ $organization = new Organization(
 	$_POST["state"],
 	$_POST["country"],
 	$_POST["admin_user_id"],
-	$_POST["orgName"],
+	trim($_POST["orgName"]),
 	$_POST["email"],
 	$email_is_google
 );
+$organization->domain = trim($_POST["domain"]);
 // Active defaults to 1 via the Organization class constructor, no need to set from form
 
 if( !$orgDAO->hasDuplicate($organization) ) {
 	$orgDAO->insert( $organization );
 }
+// Keep the public map's Google Sheet in sync (best-effort; never blocks the save).
+include_once("classes/GoogleSheetsService.php");
+GoogleSheetsService::syncOrgMap();
 include_once("session_setup.inc");
 header("Location: ModifyOrgList1.php");

--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ All settings live in `include/settings.inc` (gitignored). See `include/settings.
 | `OAUTH_REDIRECT_URI` | Full URL to `oauth_callback.php` on this server |
 | `OAUTH_TOKEN_URL` | OAuth2 token endpoint (usually the MES Portal) |
 | `OAUTH_API_URL` | OAuth2 user info endpoint |
+| `GOOGLE_MAP_SYNC_ENABLED` | Turn the org→Google Sheet map sync on/off |
+| `GOOGLE_SA_KEY_FILE` | Absolute path to the Google service-account JSON key (**store outside the web root**) |
+| `GOOGLE_MAP_SHEET_ID` | ID of the Sheet that backs the domains map |
+| `GOOGLE_MAP_SHEET_TAB` | Tab the sync owns (columns A:C) |
+
+---
+
+## Google map sync
+
+Organization changes can be pushed to the Google Sheet that backs the public "domains" map
+(Google My Maps). Enabled via the `GOOGLE_*` settings above. Setup, security notes, and the CLI
+seed/re-sync tool (`utility/sync_org_map.php`) are documented in
+[docs/google-map-sync.md](docs/google-map-sync.md).
 
 ---
 

--- a/classes/GoogleSheetsService.php
+++ b/classes/GoogleSheetsService.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * GoogleSheetsService.php
+ *
+ * Pushes the organization list into the Google Sheet that backs the public
+ * "domains" map (Google My Maps reads from that Sheet). Authenticates to the
+ * Google Sheets API v4 with a service account, using a self-signed RS256 JWT
+ * exchanged for an access token — so it needs no Composer packages, only PHP's
+ * built-in openssl, curl, and json extensions.
+ *
+ * @see EmailService for the sibling "side-effect on an event" pattern.
+ */
+class GoogleSheetsService {
+
+	/** @var bool Whether the sync is turned on ($SETTINGS["GOOGLE_MAP_SYNC_ENABLED"]). */
+	private $enabled;
+	/** @var string Absolute path to the service-account JSON key file (kept outside the web root). */
+	private $keyFile;
+	/** @var string The target spreadsheet's ID. */
+	private $sheetId;
+	/** @var string The tab (sheet) name the sync owns, e.g. "Sheet1". */
+	private $tab;
+
+	/** Google OAuth2 token endpoint for the JWT-bearer grant. */
+	const TOKEN_URL = "https://oauth2.googleapis.com/token";
+	/** Sheets API base for a spreadsheet's value ranges. */
+	const SHEETS_BASE = "https://sheets.googleapis.com/v4/spreadsheets";
+	/** The columns this sync owns/overwrites in the target tab. */
+	const COLUMNS = "A:C";
+
+	/**
+	 * Build the service from the global $SETTINGS (loaded by db.inc).
+	 *
+	 * Reads GOOGLE_MAP_SYNC_ENABLED, GOOGLE_SA_KEY_FILE, GOOGLE_MAP_SHEET_ID and
+	 * GOOGLE_MAP_SHEET_TAB. Missing keys degrade to safe defaults (disabled / empty tab).
+	 */
+	public function __construct() {
+		global $SETTINGS;
+		$this->enabled = !empty( $SETTINGS["GOOGLE_MAP_SYNC_ENABLED"] );
+		$this->keyFile = $SETTINGS["GOOGLE_SA_KEY_FILE"]   ?? "";
+		$this->sheetId = $SETTINGS["GOOGLE_MAP_SHEET_ID"]  ?? "";
+		$this->tab     = $SETTINGS["GOOGLE_MAP_SHEET_TAB"] ?? "";
+	}
+
+	/**
+	 * Best-effort entry point for the org-mutation handlers.
+	 *
+	 * Rebuilds the whole Sheet from the current active organizations. Never throws
+	 * and never blocks the caller: if the sync is disabled or anything fails, it
+	 * simply logs and returns, so an org add/edit/delete always completes. Because
+	 * every call is a full refresh, a skipped/failed call self-heals on the next one.
+	 *
+	 * Example:
+	 *   $orgDAO->insert( $organization );
+	 *   GoogleSheetsService::syncOrgMap(); // push the new roster to the map
+	 */
+	public static function syncOrgMap() {
+		try {
+			$svc = new self();
+			if( !$svc->enabled ) {
+				return;
+			}
+			$dao  = DAOFactory::getInstance()->getOrganizationDAO();
+			$rows = $dao->getMapRows();
+			$svc->syncOrganizations( $rows );
+		} catch ( \Throwable $e ) {
+			error_log( "GoogleSheetsService::syncOrgMap failed: " . $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Overwrite the target tab with a header row plus one row per organization.
+	 *
+	 * Clears the owned columns (A:C) then writes the fresh matrix, so removed orgs
+	 * disappear and the Sheet always matches the DB. The org values are the raw
+	 * UTF-8 bytes stored in the (latin1-declared) columns; json_encode accepts them
+	 * as valid UTF-8.
+	 *
+	 * @param array $rows Rows of ['org_name','city','state'] (associative) from OrganizationDAO::getMapRows().
+	 * @return bool True on success; false (and error_log) if any API call or JSON encode fails.
+	 * @throws \RuntimeException If required settings are missing or the access token cannot be obtained.
+	 */
+	public function syncOrganizations( array $rows ) {
+		if( $this->sheetId === "" || $this->keyFile === "" ) {
+			throw new \RuntimeException( "GoogleSheetsService: GOOGLE_MAP_SHEET_ID and GOOGLE_SA_KEY_FILE must be set" );
+		}
+		$token = $this->getAccessToken();
+
+		$values = array( array( "Org Name", "City", "State" ) );
+		foreach( $rows as $r ) {
+			$values[] = array(
+				(string)( $r["org_name"] ?? "" ),
+				(string)( $r["city"] ?? "" ),
+				(string)( $r["state"] ?? "" ),
+			);
+		}
+
+		$range = $this->range( self::COLUMNS );
+		// 1) Clear the columns we own so stale/removed rows are dropped.
+		$this->apiRequest( "POST", self::SHEETS_BASE . "/{$this->sheetId}/values/{$range}:clear", $token, array() );
+		// 2) Write the fresh matrix starting at the top-left of our range.
+		$writeRange = $this->range( "A1" );
+		$this->apiRequest(
+			"PUT",
+			self::SHEETS_BASE . "/{$this->sheetId}/values/{$writeRange}?valueInputOption=RAW",
+			$token,
+			array( "values" => $values )
+		);
+		return true;
+	}
+
+	/**
+	 * Build a URL-encoded A1 range, prefixed with the configured tab when set.
+	 *
+	 * @param string $a1 The A1 fragment, e.g. "A:C" or "A1".
+	 * @return string e.g. "Sheet1%21A%3AC" (tab set) or "A1" (no tab → first sheet).
+	 */
+	private function range( $a1 ) {
+		$range = ( $this->tab !== "" ) ? ( $this->tab . "!" . $a1 ) : $a1;
+		return rawurlencode( $range );
+	}
+
+	/**
+	 * Mint (and per-request cache) a Google API access token via the service-account JWT-bearer flow.
+	 *
+	 * @return string A bearer access token valid for ~1 hour.
+	 * @throws \RuntimeException If the key file is unreadable/invalid, signing fails, or the token request fails.
+	 */
+	public function getAccessToken() {
+		static $cached = null;
+		if( $cached !== null ) {
+			return $cached;
+		}
+		$raw = @file_get_contents( $this->keyFile );
+		if( $raw === false ) {
+			throw new \RuntimeException( "GoogleSheetsService: cannot read key file {$this->keyFile}" );
+		}
+		$key = json_decode( $raw, true );
+		if( !is_array( $key ) || empty( $key["client_email"] ) || empty( $key["private_key"] ) ) {
+			throw new \RuntimeException( "GoogleSheetsService: key file missing client_email/private_key" );
+		}
+
+		$now = time();
+		$header = array( "alg" => "RS256", "typ" => "JWT" );
+		$claims = array(
+			"iss"   => $key["client_email"],
+			"scope" => "https://www.googleapis.com/auth/spreadsheets",
+			"aud"   => self::TOKEN_URL,
+			"iat"   => $now,
+			"exp"   => $now + 3600,
+		);
+		$signingInput = self::b64url( json_encode( $header ) ) . "." . self::b64url( json_encode( $claims ) );
+		$signature = "";
+		if( !openssl_sign( $signingInput, $signature, $key["private_key"], OPENSSL_ALGO_SHA256 ) ) {
+			throw new \RuntimeException( "GoogleSheetsService: openssl_sign failed" );
+		}
+		$jwt = $signingInput . "." . self::b64url( $signature );
+
+		$ch = curl_init( self::TOKEN_URL );
+		curl_setopt_array( $ch, array(
+			CURLOPT_POST           => true,
+			CURLOPT_POSTFIELDS     => http_build_query( array(
+				"grant_type" => "urn:ietf:params:oauth:grant-type:jwt-bearer",
+				"assertion"  => $jwt,
+			) ),
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_TIMEOUT        => 30,
+		) );
+		$response = curl_exec( $ch );
+		$httpCode = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+		$curlErr  = curl_error( $ch );
+		curl_close( $ch );
+
+		if( $curlErr ) {
+			throw new \RuntimeException( "GoogleSheetsService: token cURL error: $curlErr" );
+		}
+		$data = json_decode( $response, true );
+		if( $httpCode !== 200 || empty( $data["access_token"] ) ) {
+			throw new \RuntimeException( "GoogleSheetsService: token request failed (HTTP $httpCode): $response" );
+		}
+		$cached = $data["access_token"];
+		return $cached;
+	}
+
+	/**
+	 * Issue a Sheets API request with a Bearer token and a JSON body.
+	 *
+	 * @param string $method HTTP method ("POST" or "PUT").
+	 * @param string $url    Full request URL.
+	 * @param string $token  Bearer access token.
+	 * @param array  $body   Body to JSON-encode (may be empty for :clear).
+	 * @return array The decoded JSON response.
+	 * @throws \RuntimeException On JSON-encode failure, cURL error, or a non-200 response.
+	 */
+	private function apiRequest( $method, $url, $token, array $body ) {
+		$payload = json_encode( $body );
+		if( $payload === false ) {
+			throw new \RuntimeException( "GoogleSheetsService: json_encode failed (" . json_last_error_msg() . ")" );
+		}
+		$ch = curl_init( $url );
+		curl_setopt_array( $ch, array(
+			CURLOPT_CUSTOMREQUEST  => $method,
+			CURLOPT_POSTFIELDS     => $payload,
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_TIMEOUT        => 30,
+			CURLOPT_HTTPHEADER     => array(
+				"Authorization: Bearer $token",
+				"Content-Type: application/json",
+			),
+		) );
+		$response = curl_exec( $ch );
+		$httpCode = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+		$curlErr  = curl_error( $ch );
+		curl_close( $ch );
+
+		if( $curlErr ) {
+			throw new \RuntimeException( "GoogleSheetsService: $method cURL error: $curlErr" );
+		}
+		if( $httpCode !== 200 ) {
+			throw new \RuntimeException( "GoogleSheetsService: $method $url failed (HTTP $httpCode): $response" );
+		}
+		return json_decode( $response, true );
+	}
+
+	/**
+	 * Base64url-encode (RFC 7515): standard base64 with +/ → -_ and no padding.
+	 *
+	 * @param string $data Raw bytes.
+	 * @return string URL-safe base64 without "=" padding.
+	 */
+	private static function b64url( $data ) {
+		return rtrim( strtr( base64_encode( $data ), "+/", "-_" ), "=" );
+	}
+}

--- a/classes/OrganizationDAO.php
+++ b/classes/OrganizationDAO.php
@@ -181,4 +181,19 @@ class OrganizationDAO {
 		$this->db->query($query, $params);
 		return $this->db->getAllRows();
 	}
+
+	/**
+	 * Return the active organizations for the public map, as name/city/state rows.
+	 *
+	 * This is the dataset pushed to the Google Sheet that backs the domains map
+	 * (see GoogleSheetsService). Only active orgs are included, ordered by name.
+	 *
+	 * @return array List of associative rows with keys 'org_name', 'city', 'state'.
+	 * @see GoogleSheetsService::syncOrganizations()
+	 */
+	function getMapRows() {
+		$query = "SELECT org_name, city, state FROM organizations WHERE active=1 ORDER BY org_name";
+		$rs = $this->db->query( $query );
+		return $rs->getAllRows();
+	}
 }

--- a/docs/google-map-sync.md
+++ b/docs/google-map-sync.md
@@ -1,0 +1,56 @@
+# Google map (Sheet) sync
+
+The public "domains" map is a Google **My Maps** map whose layer reads from a backing Google
+**Sheet**. This app keeps that Sheet in sync with the database: whenever an organization is
+added, edited, or deleted, it rewrites the Sheet from the current active organizations
+(`org_name, city, state`, ordered by name). It authenticates to the Google Sheets API v4 with a
+**service account** and needs no Composer packages (uses PHP's built-in `openssl`, `curl`,
+`json`).
+
+## How it works
+
+- `classes/GoogleSheetsService.php` — signs a service-account JWT, exchanges it for an access
+  token, then `clear`s columns `A:C` of the target tab and writes a header + one row per org.
+- `OrganizationDAO::getMapRows()` — `SELECT org_name, city, state FROM organizations WHERE active=1`.
+- The org handlers (`ModifyOrgListAddOrg.php`, `ModifyOrgList4.php`, `ModifyOrgList2.php`) call
+  `GoogleSheetsService::syncOrgMap()` after their write. It's **best-effort**: any failure is
+  logged (`error_log`) and never blocks the org save. Because each call is a full refresh, a
+  missed/failed sync self-heals on the next change or via the CLI script.
+- `utility/sync_org_map.php` — force a full sync (initial seed / cron / manual). Ignores the
+  enable flag so it can seed before you flip it on.
+
+The sync **owns columns A:C of the configured tab** and overwrites them on every run. Do not put
+manually maintained data in those columns; if the Sheet has other content, point
+`GOOGLE_MAP_SHEET_TAB` at a dedicated tab and set the My Maps layer to read from it.
+
+## One-time Google setup
+
+1. In the [Google Cloud console](https://console.cloud.google.com/), create (or pick) a project.
+2. **APIs & Services → Enable APIs** → enable **Google Sheets API**.
+3. **IAM & Admin → Service Accounts → Create service account**. No project roles are needed.
+4. On the service account, **Keys → Add key → JSON**. Download the key file.
+5. Open the target Sheet and **Share** it with the service account's `client_email`
+   (e.g. `name@project.iam.gserviceaccount.com`) as **Editor**.
+6. Copy the Sheet ID from its URL: `https://docs.google.com/spreadsheets/d/<SHEET_ID>/edit`.
+
+## Server configuration
+
+1. Put the JSON key **outside the web root**, e.g. `/etc/approvals/google-sa.json`, readable by
+   the PHP-FPM user. Never place it under the docroot.
+2. In `include/settings.inc` set:
+   ```php
+   $SETTINGS["GOOGLE_MAP_SYNC_ENABLED"] = true;
+   $SETTINGS["GOOGLE_SA_KEY_FILE"]      = "/etc/approvals/google-sa.json";
+   $SETTINGS["GOOGLE_MAP_SHEET_ID"]     = "<SHEET_ID>";
+   $SETTINGS["GOOGLE_MAP_SHEET_TAB"]    = "Sheet1"; // the tab the sync owns
+   ```
+3. Seed the Sheet: `php utility/sync_org_map.php`
+4. In My Maps, refresh the layer (or re-import) so it reflects the Sheet.
+
+## Verifying
+
+- `php utility/sync_org_map.php` prints the org count and `OK`; the Sheet shows the header plus
+  every active org, with accents rendering correctly.
+- Add/edit/delete an org in the UI and confirm the Sheet updates.
+- To confirm best-effort safety, point `GOOGLE_SA_KEY_FILE` at a bad path: org saves still
+  succeed and the failure appears only in the PHP error log.

--- a/include/settings.inc.example
+++ b/include/settings.inc.example
@@ -32,3 +32,14 @@ $SETTINGS["OAUTH_API_URL"]       = "https://portal.modernenigmasociety.org/api/a
 // When false (or key absent), the feature is completely disabled with zero overhead and full normal access for any valid member.
 // The early-access file itself is never created/committed here (user maintains it on the server, like this settings.inc).
 $SETTINGS["EARLY_ACCESS_ENABLED"] = false;
+
+// Google Sheets sync for the public "domains" map (see docs/google-map-sync.md).
+// When enabled, every organization add/edit/delete rewrites the backing Google Sheet from
+// the current active organizations (org_name, city, state). Best-effort: a failure is logged
+// and never blocks the org save.
+$SETTINGS["GOOGLE_MAP_SYNC_ENABLED"] = false;                     // master on/off switch
+// Absolute path to the service-account JSON key. MUST live OUTSIDE the web root (never under
+// the docroot) so it can't be downloaded. Share the target Sheet with the SA's client_email.
+$SETTINGS["GOOGLE_SA_KEY_FILE"]      = "/etc/approvals/google-sa.json";
+$SETTINGS["GOOGLE_MAP_SHEET_ID"]     = "your-google-sheet-id";    // the /spreadsheets/d/<ID>/ value
+$SETTINGS["GOOGLE_MAP_SHEET_TAB"]    = "Sheet1";                   // tab the sync owns (columns A:C)

--- a/utility/cleanup_org_encoding.php
+++ b/utility/cleanup_org_encoding.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * cleanup_org_encoding.php — one-time, idempotent cleanup of junk characters in
+ * organizations.domain / organizations.org_name.
+ *
+ * Fixes only genuine junk (does NOT touch legitimate accents, which are stored as
+ * valid UTF-8): converts the curly right single quote U+2019 to a straight
+ * apostrophe, and trims leading/trailing whitespace (spaces, tabs, newlines).
+ *
+ * Runs dry by default (prints a before -> after diff); pass --apply to write.
+ * Idempotent: re-running after --apply changes nothing.
+ *
+ * Usage:
+ *   php utility/cleanup_org_encoding.php           # dry run (preview only)
+ *   php utility/cleanup_org_encoding.php --apply    # write the changes
+ */
+
+// db.inc uses relative includes, so run from the web root.
+chdir( dirname( __DIR__ ) );
+require "db.inc";
+
+/**
+ * Normalize a domain/org_name value: straighten the curly apostrophe and trim whitespace.
+ *
+ * @param string|null $s Raw value from the database.
+ * @return string|null Cleaned value (null passes through unchanged).
+ */
+function clean_org_text( $s ) {
+	if( $s === null ) {
+		return null;
+	}
+	$s = str_replace( "\xE2\x80\x99", "'", $s ); // U+2019 RIGHT SINGLE QUOTATION MARK -> '
+	$s = trim( $s );                              // strip leading/trailing space, tab, newline
+	return $s;
+}
+
+$apply = in_array( "--apply", $argv, true );
+
+$rs   = $db->query( "SELECT id, domain, org_name FROM organizations" );
+$rows = $rs->getAllRows();
+
+$changed = 0;
+foreach( $rows as $r ) {
+	$d0 = $r["domain"];
+	$n0 = $r["org_name"];
+	$d1 = clean_org_text( $d0 );
+	$n1 = clean_org_text( $n0 );
+
+	if( $d1 !== $d0 || $n1 !== $n0 ) {
+		$changed++;
+		fwrite( STDOUT, "id={$r['id']}\n" );
+		if( $d1 !== $d0 ) { fwrite( STDOUT, "  domain:   [{$d0}] -> [{$d1}]\n" ); }
+		if( $n1 !== $n0 ) { fwrite( STDOUT, "  org_name: [{$n0}] -> [{$n1}]\n" ); }
+		if( $apply ) {
+			$db->query( "UPDATE organizations SET domain=?, org_name=? WHERE id=?", array( $d1, $n1, $r["id"] ) );
+		}
+	}
+}
+
+if( $apply ) {
+	fwrite( STDOUT, "[APPLIED] {$changed} row(s) changed.\n" );
+} else {
+	fwrite( STDOUT, "[DRY RUN] {$changed} row(s) would change. Re-run with --apply to write.\n" );
+}
+exit( 0 );

--- a/utility/sync_org_map.php
+++ b/utility/sync_org_map.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * sync_org_map.php — CLI one-shot full sync of active organizations to the Google map Sheet.
+ *
+ * Use it to seed the Sheet initially, to force a re-sync after config changes, or from cron.
+ * Unlike the per-mutation hook (GoogleSheetsService::syncOrgMap), this pushes regardless of
+ * the GOOGLE_MAP_SYNC_ENABLED flag, so it works for the initial seed before the flag is on.
+ *
+ * Usage:  php utility/sync_org_map.php
+ * Exit:   0 on success, 1 on failure.
+ *
+ * @see GoogleSheetsService
+ */
+
+// db.inc uses relative includes, so run from the web root.
+chdir( dirname( __DIR__ ) );
+require "db.inc";
+require_once "classes/GoogleSheetsService.php";
+
+$dao  = $daoFactory->getOrganizationDAO();
+$rows = $dao->getMapRows();
+
+fwrite( STDOUT, "Syncing " . count( $rows ) . " active organization(s) to the Google Sheet...\n" );
+
+try {
+	$svc = new GoogleSheetsService();
+	$svc->syncOrganizations( $rows );
+	fwrite( STDOUT, "OK\n" );
+	exit( 0 );
+} catch ( \Throwable $e ) {
+	fwrite( STDERR, "FAILED: " . $e->getMessage() . "\n" );
+	exit( 1 );
+}


### PR DESCRIPTION
## What

Implements the long-standing TODO: keep the Google Sheet that backs the public **domains map**
(Google My Maps) in sync with the database, and clean up junk characters in org names.

On every organization **add / edit / delete**, the app rewrites the Sheet from the current
active organizations (`org_name, city, state`, ordered by name — a full refresh, so removals
propagate and the Sheet always matches the DB).

## How

- **`classes/GoogleSheetsService.php`** — authenticates to the Google Sheets API v4 with a
  **service account**: builds a self-signed RS256 JWT (`openssl_sign`), exchanges it for an
  access token, then `values.clear` + `values.update` on the target tab. No Composer/vendor
  deps (uses built-in `openssl`/`curl`/`json`, mirroring the existing `oauth_callback.php` cURL
  pattern).
- **`OrganizationDAO::getMapRows()`** — `SELECT org_name, city, state FROM organizations WHERE active=1`.
- **Hooks** in `ModifyOrgListAddOrg.php`, `ModifyOrgList4.php`, `ModifyOrgList2.php` call
  `GoogleSheetsService::syncOrgMap()` after their write. **Best-effort**: all failures are
  caught + `error_log`'d and never block/500 the org operation; a failed sync self-heals on the
  next change (full refresh).
- **`utility/sync_org_map.php`** — CLI full sync for initial seed / cron / manual re-sync
  (bypasses the enable flag so it can seed first).
- **Data cleanup** — `utility/cleanup_org_encoding.php` (one-time, **dry-run by default**,
  `--apply` to write): straightens the curly `’` (U+2019) to `'` and trims stray whitespace
  (e.g. the leading TAB in `GA-011-D`), leaving legitimate French accents (é/è/à) untouched.
  Also `trim()`s org_name/domain on add/edit to prevent recurrence.

## Config / security

- New `$SETTINGS`: `GOOGLE_MAP_SYNC_ENABLED` (**default false**), `GOOGLE_SA_KEY_FILE`,
  `GOOGLE_MAP_SHEET_ID`, `GOOGLE_MAP_SHEET_TAB`.
- The service-account JSON key **must live outside the web root**; documented in
  `docs/google-map-sync.md`. (A follow-up also adds `.json` to the nginx deny list as
  defense-in-depth.)
- The sync **owns columns A:C of the configured tab** and overwrites them each run — point the
  My Maps layer at that tab and don't keep manual data there.

## Testing

- `php -l` clean on all changed/new files.
- Ships with no automated suite (repo has none); verify via `utility/cleanup_org_encoding.php`
  (dry-run then `--apply`), `utility/sync_org_map.php` (seed), and add/edit/delete in the UI. See
  `docs/google-map-sync.md`.

Off by default — safe to merge before the Google side is configured.
