### PR TITLE
chore: gitignore Google service-account key files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Secrets — never commit
 include/settings.inc
+# Google service-account key(s) — never commit; on servers keep OUTSIDE the web root
+find-a-game-207620-ddabf9831915.json
+google-sa*.json
+/*.json
 
 # Logs
 *.log


### PR DESCRIPTION
Ensures the Google service-account JSON key can never be committed or deployed into the web root.

- Ignores the specific key `find-a-game-207620-ddabf9831915.json`.
- Adds `google-sa*.json` (the documented server key name) and a root-level `/*.json` guard (mirrors the existing `/*.sql` convention).
- No `.json` files are tracked in the repo, so this is safe.

The key itself lives only on the local machine / outside the server web root and is never read or committed.