### PR TITLE
feat: match sheet header + add RST region contact column to map sync

### DIFF
--- a/classes/GoogleSheetsService.php
+++ b/classes/GoogleSheetsService.php
@@ -26,7 +26,7 @@ class GoogleSheetsService {
 	/** Sheets API base for a spreadsheet's value ranges. */
 	const SHEETS_BASE = "https://sheets.googleapis.com/v4/spreadsheets";
 	/** The columns this sync owns/overwrites in the target tab. */
-	const COLUMNS = "A:C";
+	const COLUMNS = "A:D";
 
 	/**
 	 * Build the service from the global $SETTINGS (loaded by db.inc).
@@ -71,12 +71,12 @@ class GoogleSheetsService {
 	/**
 	 * Overwrite the target tab with a header row plus one row per organization.
 	 *
-	 * Clears the owned columns (A:C) then writes the fresh matrix, so removed orgs
+	 * Clears the owned columns (A:D) then writes the fresh matrix, so removed orgs
 	 * disappear and the Sheet always matches the DB. The org values are the raw
 	 * UTF-8 bytes stored in the (latin1-declared) columns; json_encode accepts them
 	 * as valid UTF-8.
 	 *
-	 * @param array $rows Rows of ['org_name','city','state'] (associative) from OrganizationDAO::getMapRows().
+	 * @param array $rows Rows of ['org_name','city','state','region_contact'] (associative) from OrganizationDAO::getMapRows().
 	 * @return bool True on success; false (and error_log) if any API call or JSON encode fails.
 	 * @throws \RuntimeException If required settings are missing or the access token cannot be obtained.
 	 */
@@ -86,12 +86,13 @@ class GoogleSheetsService {
 		}
 		$token = $this->getAccessToken();
 
-		$values = array( array( "Name", "City", "State" ) );
+		$values = array( array( "Name", "City", "State", "RST Contact" ) );
 		foreach( $rows as $r ) {
 			$values[] = array(
 				(string)( $r["org_name"] ?? "" ),
 				(string)( $r["city"] ?? "" ),
 				(string)( $r["state"] ?? "" ),
+				(string)( $r["region_contact"] ?? "" ),
 			);
 		}
 
@@ -169,7 +170,6 @@ class GoogleSheetsService {
 		$response = curl_exec( $ch );
 		$httpCode = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
 		$curlErr  = curl_error( $ch );
-		curl_close( $ch );
 
 		if( $curlErr ) {
 			throw new \RuntimeException( "GoogleSheetsService: token cURL error: $curlErr" );
@@ -211,7 +211,6 @@ class GoogleSheetsService {
 		$response = curl_exec( $ch );
 		$httpCode = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
 		$curlErr  = curl_error( $ch );
-		curl_close( $ch );
 
 		if( $curlErr ) {
 			throw new \RuntimeException( "GoogleSheetsService: $method cURL error: $curlErr" );

--- a/classes/GoogleSheetsService.php
+++ b/classes/GoogleSheetsService.php
@@ -86,7 +86,7 @@ class GoogleSheetsService {
 		}
 		$token = $this->getAccessToken();
 
-		$values = array( array( "Org Name", "City", "State" ) );
+		$values = array( array( "Name", "City", "State" ) );
 		foreach( $rows as $r ) {
 			$values[] = array(
 				(string)( $r["org_name"] ?? "" ),

--- a/classes/OrganizationDAO.php
+++ b/classes/OrganizationDAO.php
@@ -183,16 +183,24 @@ class OrganizationDAO {
 	}
 
 	/**
-	 * Return the active organizations for the public map, as name/city/state rows.
+	 * Return the active organizations for the public map, as name/city/state/contact rows.
 	 *
 	 * This is the dataset pushed to the Google Sheet that backs the domains map
 	 * (see GoogleSheetsService). Only active orgs are included, ordered by name.
+	 * 'region_contact' is the role-based RST contact email of the region the org sits
+	 * in (the region-level org's `email`, e.g. wrrst@wr.modernenigmasociety.org), so the
+	 * map always shows a way to reach someone. It is empty for orgs not within a region
+	 * (nation/globe level).
 	 *
-	 * @return array List of associative rows with keys 'org_name', 'city', 'state'.
+	 * @return array List of associative rows with keys 'org_name', 'city', 'state', 'region_contact'.
 	 * @see GoogleSheetsService::syncOrganizations()
 	 */
 	function getMapRows() {
-		$query = "SELECT org_name, city, state FROM organizations WHERE active=1 ORDER BY org_name";
+		$query = "SELECT o.org_name, o.city, o.state, " .
+			"(SELECT r.email FROM organizations r " .
+			" WHERE r.globe=o.globe AND r.nation=o.nation AND r.region=o.region " .
+			"   AND r.domain='' AND r.chapter='' AND r.region<>'' LIMIT 1) AS region_contact " .
+			"FROM organizations o WHERE o.active=1 ORDER BY o.org_name";
 		$rs = $this->db->query( $query );
 		return $rs->getAllRows();
 	}

--- a/docs/google-map-sync.md
+++ b/docs/google-map-sync.md
@@ -3,15 +3,20 @@
 The public "domains" map is a Google **My Maps** map whose layer reads from a backing Google
 **Sheet**. This app keeps that Sheet in sync with the database: whenever an organization is
 added, edited, or deleted, it rewrites the Sheet from the current active organizations
-(`org_name, city, state`, ordered by name). It authenticates to the Google Sheets API v4 with a
-**service account** and needs no Composer packages (uses PHP's built-in `openssl`, `curl`,
-`json`).
+(`Name, City, State, RST Contact`, ordered by name). It authenticates to the Google Sheets API
+v4 with a **service account** and needs no Composer packages (uses PHP's built-in `openssl`,
+`curl`, `json`).
+
+The **RST Contact** column is the role-based contact email of the region each org sits in (the
+region-level org's `email`, e.g. `wrrst@wr.modernenigmasociety.org`), so every mapped location
+shows a way to reach a storyteller. It is blank for orgs not within a region (nation/globe level).
 
 ## How it works
 
 - `classes/GoogleSheetsService.php` — signs a service-account JWT, exchanges it for an access
-  token, then `clear`s columns `A:C` of the target tab and writes a header + one row per org.
-- `OrganizationDAO::getMapRows()` — `SELECT org_name, city, state FROM organizations WHERE active=1`.
+  token, then `clear`s columns `A:D` of the target tab and writes a header + one row per org.
+- `OrganizationDAO::getMapRows()` — active orgs as `org_name, city, state`, plus `region_contact`
+  (the region-level org's `email`) resolved from each org's globe/nation/region.
 - The org handlers (`ModifyOrgListAddOrg.php`, `ModifyOrgList4.php`, `ModifyOrgList2.php`) call
   `GoogleSheetsService::syncOrgMap()` after their write. It's **best-effort**: any failure is
   logged (`error_log`) and never blocks the org save. Because each call is a full refresh, a
@@ -19,7 +24,7 @@ added, edited, or deleted, it rewrites the Sheet from the current active organiz
 - `utility/sync_org_map.php` — force a full sync (initial seed / cron / manual). Ignores the
   enable flag so it can seed before you flip it on.
 
-The sync **owns columns A:C of the configured tab** and overwrites them on every run. Do not put
+The sync **owns columns A:D of the configured tab** and overwrites them on every run. Do not put
 manually maintained data in those columns; if the Sheet has other content, point
 `GOOGLE_MAP_SHEET_TAB` at a dedicated tab and set the My Maps layer to read from it.
 

--- a/include/settings.inc.example
+++ b/include/settings.inc.example
@@ -35,8 +35,8 @@ $SETTINGS["EARLY_ACCESS_ENABLED"] = false;
 
 // Google Sheets sync for the public "domains" map (see docs/google-map-sync.md).
 // When enabled, every organization add/edit/delete rewrites the backing Google Sheet from
-// the current active organizations (org_name, city, state). Best-effort: a failure is logged
-// and never blocks the org save.
+// the current active organizations (Name, City, State, RST Contact). Best-effort: a failure is
+// logged and never blocks the org save.
 $SETTINGS["GOOGLE_MAP_SYNC_ENABLED"] = false;                     // master on/off switch
 // Absolute path to the service-account JSON key. MUST live OUTSIDE the web root (never under
 // the docroot) so it can't be downloaded. Share the target Sheet with the SA's client_email.


### PR DESCRIPTION
Enablement-driven changes to the org→Google Sheet map sync (feature from #6):

1. **Match the sheet header** — the live sheet (tab `Sheet1`) uses `Name | City | State`; the My Maps layer maps by those header names. Write `Name` (not `Org Name`) so the full-refresh preserves the heading.
2. **Add an `RST Contact` column (D)** — the role-based contact email of the region each org sits in (the region-level org's `email`, e.g. `wrrst@wr.modernenigmasociety.org`), so every mapped location shows a way to reach a storyteller. Resolved in `OrganizationDAO::getMapRows()` via a correlated subquery on globe/nation/region; blank for nation/globe-level orgs. Owned range widened to `A:D`.
3. Drop deprecated `curl_close()` calls (no-ops on PHP 8).

Discovered by reading the live sheet + org data with the service account during enablement. `php -l` clean. Follow-up tracked separately: switch the contact to a per-org storyteller address once org-based emails exist.