### PR TITLE
fix: map sync includes only real domain locations (exclude regions/virtual/test)

### DIFF
--- a/classes/OrganizationDAO.php
+++ b/classes/OrganizationDAO.php
@@ -183,14 +183,15 @@ class OrganizationDAO {
 	}
 
 	/**
-	 * Return the active organizations for the public map, as name/city/state/contact rows.
+	 * Return the mappable organizations for the public map, as name/city/state/contact rows.
 	 *
 	 * This is the dataset pushed to the Google Sheet that backs the domains map
-	 * (see GoogleSheetsService). Only active orgs are included, ordered by name.
-	 * 'region_contact' is the role-based RST contact email of the region the org sits
-	 * in (the region-level org's `email`, e.g. wrrst@wr.modernenigmasociety.org), so the
-	 * map always shows a way to reach someone. It is empty for orgs not within a region
-	 * (nation/globe level).
+	 * (see GoogleSheetsService). Only real, physical **domain-level** orgs are included:
+	 * region/nation/globe entries (empty domain) are excluded, as are virtual games and
+	 * test entries (matched by "virtual"/"test" in the name, or "vir"/"test" in the domain
+	 * code). Ordered by name. 'region_contact' is the role-based RST contact email of the
+	 * region the org sits in (the region-level org's `email`, e.g.
+	 * wrrst@wr.modernenigmasociety.org), so the map always shows a way to reach someone.
 	 *
 	 * @return array List of associative rows with keys 'org_name', 'city', 'state', 'region_contact'.
 	 * @see GoogleSheetsService::syncOrganizations()
@@ -200,7 +201,12 @@ class OrganizationDAO {
 			"(SELECT r.email FROM organizations r " .
 			" WHERE r.globe=o.globe AND r.nation=o.nation AND r.region=o.region " .
 			"   AND r.domain='' AND r.chapter='' AND r.region<>'' LIMIT 1) AS region_contact " .
-			"FROM organizations o WHERE o.active=1 ORDER BY o.org_name";
+			"FROM organizations o " .
+			"WHERE o.active=1 " .
+			"  AND o.domain <> '' " .
+			"  AND o.org_name NOT LIKE '%virtual%' AND o.org_name NOT LIKE '%test%' " .
+			"  AND o.domain   NOT LIKE '%vir%'     AND o.domain   NOT LIKE '%test%' " .
+			"ORDER BY o.org_name";
 		$rs = $this->db->query( $query );
 		return $rs->getAllRows();
 	}

--- a/docs/google-map-sync.md
+++ b/docs/google-map-sync.md
@@ -15,8 +15,10 @@ shows a way to reach a storyteller. It is blank for orgs not within a region (na
 
 - `classes/GoogleSheetsService.php` — signs a service-account JWT, exchanges it for an access
   token, then `clear`s columns `A:D` of the target tab and writes a header + one row per org.
-- `OrganizationDAO::getMapRows()` — active orgs as `org_name, city, state`, plus `region_contact`
-  (the region-level org's `email`) resolved from each org's globe/nation/region.
+- `OrganizationDAO::getMapRows()` — mappable orgs as `org_name, city, state`, plus `region_contact`
+  (the region-level org's `email`) resolved from each org's globe/nation/region. Only real
+  **domain-level** orgs are included: region/nation/globe entries (empty domain) and virtual/test
+  entries are excluded.
 - The org handlers (`ModifyOrgListAddOrg.php`, `ModifyOrgList4.php`, `ModifyOrgList2.php`) call
   `GoogleSheetsService::syncOrgMap()` after their write. It's **best-effort**: any failure is
   logged (`error_log`) and never blocks the org save. Because each call is a full refresh, a


### PR DESCRIPTION
The seeded sheet included region/nation/globe rows, the Global Office, and virtual venues. Restrict `getMapRows()` to real physical domains:

- `domain <> ''` — drops region/nation/globe entries.
- exclude `%virtual%` (name) / `%vir%` (domain code) — drops virtual games.
- exclude `%test%` (name/domain) — drops test entries.

Result: ~13 real domain locations. Re-seeded after deploy.