### PR TITLE
fix: exclude retired chapters from map sync

### DIFF
--- a/classes/OrganizationDAO.php
+++ b/classes/OrganizationDAO.php
@@ -187,9 +187,10 @@ class OrganizationDAO {
 	 *
 	 * This is the dataset pushed to the Google Sheet that backs the domains map
 	 * (see GoogleSheetsService). Only real, physical **domain-level** orgs are included:
-	 * region/nation/globe entries (empty domain) are excluded, as are virtual games and
-	 * test entries (matched by "virtual"/"test" in the name, or "vir"/"test" in the domain
-	 * code). Ordered by name. 'region_contact' is the role-based RST contact email of the
+	 * region/nation/globe entries (empty domain) are excluded, as are retired chapters
+	 * (non-empty chapter), virtual games, and test entries (matched by "virtual"/"test" in
+	 * the name, or "vir"/"test" in the domain code). Ordered by name. 'region_contact' is
+	 * the role-based RST contact email of the
 	 * region the org sits in (the region-level org's `email`, e.g.
 	 * wrrst@wr.modernenigmasociety.org), so the map always shows a way to reach someone.
 	 *
@@ -204,6 +205,7 @@ class OrganizationDAO {
 			"FROM organizations o " .
 			"WHERE o.active=1 " .
 			"  AND o.domain <> '' " .
+			"  AND o.chapter = '' " .
 			"  AND o.org_name NOT LIKE '%virtual%' AND o.org_name NOT LIKE '%test%' " .
 			"  AND o.domain   NOT LIKE '%vir%'     AND o.domain   NOT LIKE '%test%' " .
 			"ORDER BY o.org_name";


### PR DESCRIPTION
A chapter-level org (non-empty `chapter`) was showing on the map as a duplicate of its parent domain (the second 'Hawaii 5 Oh!' row, chapter `HI-005-D`). Chapters are retired, so add `chapter = ''` to `getMapRows()`. Drops that one row → 12 clean domains.