### PR TITLE
fix: session cookie domain -> legacy.modernenigmasociety.org

### DIFF
--- a/include/session_start.inc
+++ b/include/session_start.inc
@@ -3,7 +3,7 @@
 session_set_cookie_params([
     'lifetime' => 0,                    // expire when browser closes
     'path'     => '/',
-    'domain'   => 'olddb.modernenigmasociety.org',
+    'domain'   => 'legacy.modernenigmasociety.org',
     'secure'   => false,                // false for HTTP testing
     'httponly' => true,
     'samesite' => 'Lax'

--- a/utility/index2.php
+++ b/utility/index2.php
@@ -2,7 +2,7 @@
 session_set_cookie_params([
     'lifetime' => 0,
     'path'     => '/',
-    'domain'   => 'olddb.modernenigmasociety.org',
+    'domain'   => 'legacy.modernenigmasociety.org',
     'secure'   => false,
     'httponly' => true,
     'samesite' => 'Lax'


### PR DESCRIPTION
## What
Corrects the session cookie `domain` from `olddb.modernenigmasociety.org` to `legacy.modernenigmasociety.org` in:
- `include/session_start.inc` (included by all pages)
- `utility/index2.php` (OAuth login entrypoint)

## Why
The application is served at `legacy.modernenigmasociety.org`, so cookies were scoped to the wrong host. The server already carried this fix as a manual, **uncommitted** hotfix to `session_start.inc`; this PR captures it in the repo (plus the matching `index2.php` occurrence) so the code matches the live deployment and future `git pull` deploys don't revert it.

Found during a repo/deploy hygiene pass.