### PR TITLE
fix: resolve error-log findings + add PHPUnit test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ templates_c/
 
 # Submodule (managed separately)
 PHP-OAuth2
+
+# PHPUnit (dev-only test framework; fetch the phar via tools/get-phpunit.sh|.ps1)
+/tools/phpunit.phar
+/.phpunit.cache/
+/.phpunit.result.cache

--- a/AppDetails.php
+++ b/AppDetails.php
@@ -80,6 +80,7 @@ if ( isset($_POST['delete'] ) && isset($_POST["id"] ) ) {
 	}
 }
 
+$changed = array();
 if( $mode == 'doAdd' || $mode == 'doEdit' ) {
 	$thissubmitvalue = "Enter New Values";
 
@@ -334,14 +335,14 @@ if( $mode == 'doAdd' || $mode == 'doEdit' ) {
         if( $ThisStatus != "" ) {
         	$applicationDAO->updateStatus( $app_info->id, $ThisStatus );
         	$revisionDAO->insert( new Revision( $app_info->id, $_SESSION["user_id"], "Status set to $ThisStatus" ) );
-        	$emailService->sendChangesEmail( $app_info, $changed );
+        	$emailService->sendChangesEmail( $app_info, implode(", ", $changed) );
         }
         header ( "Location: AppDetails.php?id=$app_info->id&mode=display&message=updatecomplete&" );
         exit();
       } else if ( isset($_POST["reinstate"]) ) {
         $applicationDAO->updateStatus( $app_info->id, "Pending Low" );
         $revisionDAO->insert( new Revision( $app_info->id, $_SESSION["user_id"], "Status set to Pending Low" ) );
-        $emailService->sendChangesEmail( $app_info, $changed );
+        $emailService->sendChangesEmail( $app_info, implode(", ", $changed) );
         header ( "Location: AppDetails.php?id=$app_info->id&mode=display&message=updatecomplete&" );
         exit();
       } else if ( isset($_POST["remove"]) ) {

--- a/ChangeCharacterVSSStatus.php
+++ b/ChangeCharacterVSSStatus.php
@@ -29,7 +29,7 @@
             "Content-Type: text/html\r\n");
     }
   } elseif ( $_GET["Action"]=="Accept" ) {
-	error_log(date('Y-m-d h:i:s').'APPROVED CHAR '.$_GET['character_id'].' USER '.$_SESSION['user_id']."\n",3,'/var/www/html/vssmove.log');
+	error_log(date('Y-m-d h:i:s').'APPROVED CHAR '.$_GET['character_id'].' USER '.$_SESSION['user_id']."\n",3,__DIR__ . '/vssmove.log');
     $db->query("UPDATE characters SET approved_in_vss='1' where id=?", [$char_id]);
     // Email to user saying accepted;
     if( $email_info['email'] != "" && $character_owner_active ) {

--- a/MoveCharacter2.php
+++ b/MoveCharacter2.php
@@ -52,7 +52,7 @@
   } 
   
   if( $vss_id != 0 ) {
- 	error_log(date('Y-m-d h:i:s').' CHAR '.$_POST['char_id'].' VSS '.$vss_id.' USER '.$_SESSION['user_id']."\n",3,'/var/www/approvals_2017/vssmove.log');
+ 	error_log(date('Y-m-d h:i:s').' CHAR '.$_POST['char_id'].' VSS '.$vss_id.' USER '.$_SESSION['user_id']."\n",3,__DIR__ . '/vssmove.log');
     $query="UPDATE characters SET vss_id=?, approved_in_vss='0' WHERE id=?";
 	$params = [ $vss_id, $_POST['char_id'] ];
     $db->query($query, $params);

--- a/UserFeedback.php
+++ b/UserFeedback.php
@@ -19,6 +19,7 @@ active, a yes/no (bit)
 
   include_once("header.inc");
   include_once("titlebar.php");
+  include_once("include/pagination.inc");
 
   // Grab the first message number from the URL
   $first_message = isset( $_GET['msg'] ) ? $_GET['msg'] : 0 ;
@@ -68,9 +69,9 @@ active, a yes/no (bit)
 	$query.="order by active desc, commentdate desc ".
        "limit ?, ?";
   if ( !isset($_GET["ShowAllRecords"]) ) {
-    $result = $db->query($query, [$_SESSION["last_login_date"], $_SESSION["last_login_date"], intval($first_message), intval($msg_display)]);
+    $result = $db->query($query, [$_SESSION["last_login_date"], $_SESSION["last_login_date"], paginationOffset($first_message), intval($msg_display)]);
   } else {
-    $result = $db->query($query, [intval($first_message), intval($msg_display)]);
+    $result = $db->query($query, [paginationOffset($first_message), intval($msg_display)]);
   }
 
 	if ( !isset($_GET["ShowAllRecords"]) ) {

--- a/UserFeedbackShowThread.php
+++ b/UserFeedbackShowThread.php
@@ -18,6 +18,7 @@ active, a yes/no (bit)
   $pagetitle="Enter User Feedback";
   include_once("header.inc");
   include_once("titlebar.php");
+  include_once("include/pagination.inc");
 
   // Grab the first message number from the URL
   $first_message = isset( $_GET['msg'] ) ? intval($_GET['msg']) : 0 ;
@@ -82,7 +83,7 @@ active, a yes/no (bit)
        "where parent_id=? ".
        "order by active desc, commentdate desc ".
        "limit ?, ?";
-  $res = $db->query($query, [$_GET["id"], $first_message, $msg_display]);
+  $res = $db->query($query, [$_GET["id"], paginationOffset($first_message), $msg_display]);
   $msg_count = 0;
   while ( $row=$res->nextRow() ) {
     $msg_count += 1;

--- a/UserList.php
+++ b/UserList.php
@@ -4,6 +4,7 @@
 	include_once("header.inc");
 	include_once("titlebar.php");
 	include_once("services/UserService.class.php");
+	include_once("include/pagination.inc");
 
 	$filter = array();
 
@@ -19,7 +20,7 @@
 	}
 
 
-	$filter["skip"]   = isset($_GET["skip"])   ? $_GET["skip"] : "0";
+	$filter["skip"]   = isset($_GET["skip"])   ? paginationOffset($_GET["skip"]) : 0;
 	$filter["sortby"] = isset($_GET["sortby"]) ? $_GET["sortby"] : "Affiliation";
 	$filter["search"] = isset($_GET["search"]) ? $_GET["search"] : "";
 
@@ -121,7 +122,7 @@
 	}
 
 	if ( $filter["skip"] + 20 < $total_users )	{
-		$prevskip=( intval($filter["skip"]/20) - 1 ) * 20 ;
+		$prevskip=( intval($filter["skip"]/20) + 1 ) * 20 ;
 		$prevquery = $basequery . (""==$basequery?"":"&") . "skip=".$prevskip;
 		echo("<a href=\"UserList.php?$prevquery\">></a>\n");
 		$prevskip=intval($total_users/20) * 20 ;

--- a/classes/ApplicationService.php
+++ b/classes/ApplicationService.php
@@ -18,6 +18,19 @@ class ApplicationService {
 		$this->userInfoDAO = $userInfoDAO;
 	}
 
+	/**
+	 * Resolves the user id of the "low storyteller" responsible for approving an application.
+	 *
+	 * Branches on the application's character (when set) or its org (when not):
+	 * - No character_id: the storyteller of the org's parent org.
+	 * - character.vss_id < 0: the storyteller of the org identified by -vss_id.
+	 * - character.vss_id == 0: the storyteller of the character's own org, or, when the
+	 *   character has no org, the storyteller of the owning player's org (looked up via
+	 *   UserInfoDAO::getUserInfo, which returns an associative array).
+	 * - character.vss_id > 0: the storyteller of that VSS.
+	 *
+	 * @return mixed the resolved storyteller's user id
+	 */
 	function getLowST( $application ) {
 		if( $application->character_id == "" ) {
 			$parent_org_id = $this->organizationDAO->getParentOrgID( $application->org_id );
@@ -27,16 +40,16 @@ class ApplicationService {
 
 			if( $character->vss_id < 0 ) {
 				$st_id = $this->organizationDAO->getOrgSTID( 0-$character->vss_id );
-			} else if( $vss_id == 0 ) {
+			} else if( $character->vss_id == 0 ) {
 				if( $character->org_id == 0 ) {
 					$userinfo = $this->userInfoDAO->getUserInfo( $character->user_id );
-					$org_id = $player->org_id;
+					$org_id = $userinfo['org_id'];
 				} else {
 					$org_id = $character->org_id;
 				}
 				$st_id = $this->organizationDAO->getOrgSTID( $org_id );
 			} else {
-				$st_id = $this->vssDAO->getVSSSTID( $vss_id );
+				$st_id = $this->vssDAO->getVSSSTID( $character->vss_id );
 			}
 		}
 		return $st_id;

--- a/classes/RevisionDAO.class.php
+++ b/classes/RevisionDAO.class.php
@@ -8,7 +8,17 @@ class RevisionDAO {
 		$this->db = $db;
 	}
 
-	function insert( &$revision ) {
+	/**
+	 * Inserts a Revision into the revisions table and sets its id from the new row.
+	 * Takes the Revision by value (not by reference): only the object's `id` property
+	 * is set after insert, and since objects are passed by handle in PHP, that
+	 * mutation is visible to the caller without needing a reference parameter. This
+	 * also lets callers pass a `new Revision(...)` expression directly without
+	 * triggering the "Only variables should be passed by reference" notice.
+	 *
+	 * @param Revision $revision The revision to persist; its `id` is populated on return.
+	 */
+	function insert( $revision ) {
 		$query = "INSERT INTO revisions (application_id, user_id, revision_date, revision) VALUES (?, ?, now(), ?)";
 		$this->db->query( $query, [$revision->application_id, $revision->user_id, $revision->revision] );
 		$revision->id = $this->db->getInsertID();

--- a/include/pagination.inc
+++ b/include/pagination.inc
@@ -1,0 +1,22 @@
+<?php
+
+if ( ! function_exists('paginationOffset') ) {
+	/**
+	 * Clamps an untrusted pagination offset to a non-negative integer so it
+	 * can't produce a negative SQL LIMIT offset (which throws a fatal
+	 * mysqli_sql_exception).
+	 *
+	 * @param $raw Untrusted offset value, typically read straight from
+	 *             $_GET (e.g. a "skip" or "msg" query parameter). May be a
+	 *             string, int, null, or anything else int-castable.
+	 * @return The offset as a non-negative integer, safe to splice into a
+	 *         `LIMIT offset, count` clause.
+	 *
+	 * @example
+	 *   paginationOffset("-20"); // => 0
+	 *   paginationOffset("60");  // => 60
+	 */
+	function paginationOffset( $raw ): int {
+		return max( 0, (int) $raw );
+	}
+}

--- a/include/session_start.inc
+++ b/include/session_start.inc
@@ -10,7 +10,4 @@ session_set_cookie_params([
 ]);
 session_name("approvals_2017");
 session_start();
-
-// Debug line (remove after testing)
-error_log("Session started with ID: " . session_id());
 ?>

--- a/index.php
+++ b/index.php
@@ -1,21 +1,14 @@
 <?php
-error_log("Point 1: Start of index.php");
-
 include_once("db.inc");
-error_log("Point 3: db.inc included");
 
 include_once("include/oauth_helper.php");
-error_log("Point 4: oauth_helper.php included");
 
 handle_oauth_login();
-error_log("Point 5: handle_oauth_login completed");
 
 // If we reach here, user is logged in - set up additional session data
 if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true) {
-    error_log("Point 6: User is logged in - starting member check");
     $member_number = $_SESSION['cam_number'] ?? null;
     if (!$member_number || $member_number == 'undefined') {
-        error_log("Point 7: No member number - exiting");
         echo "You do not appear to have a member number. Please return to <a href='http://portal.modernenigmasociety.org/membership/'>the Portal</a> to either become a member or claim your membership number";
         exit;
     }
@@ -23,15 +16,12 @@ if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true) {
     enforce_early_access();   // early access / phased rollout gate (if $SETTINGS["EARLY_ACCESS_ENABLED"] is true)
                               // non-whitelisted users (by cam_number vs the "early-access" file) are shown the denial message here
     $_SESSION['user_id'] = getUserID($_SESSION['cam_number']);
-    error_log("Point 8: user_id set");
     include_once("session_setup.inc");
 
     //include_once("session_setup.inc");
-    //error_log("Point 9: session_setup.inc included");
 
     // Redirect to appropriate page
     if (!$_SESSION['org_id']) {
-        error_log("Point 10: Redirecting to UserDisplay.php");
         header('Location: UserDisplay.php?mode=edit');
         echo("<a href='UserDisplay.php?mode=edit'>UserDisplay.php?mode=edit</a>");
     } else if ( ( array_key_exists( "admin_org_list", $_SESSION ) &&
@@ -39,17 +29,14 @@ if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true) {
                  ( array_key_exists( "admin_vss_list", $_SESSION ) &&
                  count($_SESSION["admin_vss_list"] ) > 0 )
     ) {
-        error_log("Point 11: Redirecting to app_main.php");
         header( "Location: app_main.php" );
         echo("<a href='app_main.php'>app_main.php</a>");
     } else {
-        error_log("Point 12: Redirecting to MyApps.php");
         header( "Location: MyApps.php" );
         echo("<a href='MyApps.php'>MyApps.php</a>");
     }
     exit;
 } else {
-    error_log("Point 13: Not logged in - unsetting user_id");
     unset($_SESSION['user_id']);
     echo "Login failed. Please try again.";
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  PHPUnit configuration for approvals_rewrite.
+
+  The project has no composer; PHPUnit is run from a self-contained phar fetched
+  into tools/phpunit.phar (gitignored) via the tools/get-phpunit scripts.
+  Run "php tools/phpunit.phar" for all suites (see tests/README.md).
+
+  Unit tests inject stub doubles for DAOs, so they need no database or settings.inc.
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         failOnWarning="true"
+         failOnNotice="true">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/services/UserService.class.php
+++ b/services/UserService.class.php
@@ -1,5 +1,6 @@
 <?php
 include_once ("vo/UserVO.class.php");
+include_once("include/pagination.inc");
 
 class UserService {
 	function UserService() {
@@ -26,7 +27,7 @@ class UserService {
 		$query .= sprintf(
 			"ORDER BY lastname, firstname ".
 			"LIMIT %d, 20",
-			(int)$filter["skip"]
+			paginationOffset($filter["skip"])
 		);
 
 		$rs = $db->query($query);

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,37 @@
+# Tests
+
+This project has **no composer**. The test framework is PHPUnit, run from a
+self-contained phar that is **gitignored** (it must never be deployed to the web root).
+
+## One-time setup
+
+Fetch the phar into `tools/phpunit.phar`:
+
+```bash
+tools/get-phpunit.sh        # Linux/macOS/Git Bash
+```
+```powershell
+tools\get-phpunit.ps1       # Windows PowerShell
+```
+
+## Running
+
+```bash
+php tools/phpunit.phar                    # all suites (config: phpunit.xml)
+php tools/phpunit.phar --testsuite unit   # unit suite only
+```
+
+## Layout
+
+- `tests/Unit/` — fast, offline unit tests. They inject **stub doubles** for DAOs, so
+  they need no database and never load `include/settings.inc`. See `tests/bootstrap.php`.
+- `tests/test_final_approval.php` — a pre-existing self-contained **live-DB integration**
+  script (its own assert harness). Run directly: `php tests/test_final_approval.php`.
+  It is not part of the `unit` suite because it requires DB connectivity and fixtures.
+
+## Writing a unit test
+
+`require_once` the app file under test at the top (the bootstrap has already `chdir`'d to
+the repo root), then inject anonymous-class stubs for its collaborators. Example pattern:
+`tests/Unit/GetLowSTTest.php` constructs `ApplicationService` with four stub DAOs and asserts
+the resolved storyteller id for each `vss_id` branch.

--- a/tests/Unit/GetLowSTTest.php
+++ b/tests/Unit/GetLowSTTest.php
@@ -1,0 +1,108 @@
+<?php
+require_once 'classes/ApplicationService.php';
+
+/**
+ * Unit tests for ApplicationService::getLowST(), covering all four routing
+ * branches (org-only application, negative/zero/positive character vss_id)
+ * against stub DAOs so no database is required.
+ *
+ * @see ApplicationService::getLowST()
+ */
+final class GetLowSTTest extends \PHPUnit\Framework\TestCase {
+
+	/**
+	 * Builds an ApplicationService wired with stub DAOs that echo their inputs
+	 * back in a recognisable form, so assertions can trace which branch ran.
+	 */
+	private function makeService(): ApplicationService {
+		$characterDAO = new class {
+			public $vss = 0;
+			public $org = 0;
+			public $uid = 0;
+			function readByID( $id ) {
+				$o = new stdClass;
+				$o->vss_id = $this->vss;
+				$o->org_id = $this->org;
+				$o->user_id = $this->uid;
+				return $o;
+			}
+		};
+		$orgDAO = new class {
+			function getOrgSTID( $id ) { return "ORG:$id"; }
+			function getParentOrgID( $id ) { return $id + 1000; }
+		};
+		$vssDAO = new class {
+			function getVSSSTID( $id ) { return "VSS:$id"; }
+		};
+		$userDAO = new class {
+			function getUserInfo( $id ) { return [ 'org_id' => 777 ]; }
+		};
+
+		$this->characterDAO = $characterDAO;
+		return new ApplicationService( $orgDAO, $characterDAO, $vssDAO, $userDAO );
+	}
+
+	private $characterDAO;
+
+	/** vss_id < 0 resolves via the org identified by -vss_id. */
+	public function testNegativeVssIdResolvesOrgByNegation(): void {
+		$service = $this->makeService();
+		$this->characterDAO->vss = -50;
+
+		$application = new stdClass;
+		$application->character_id = 1;
+		$application->org_id = 0;
+
+		$this->assertSame( "ORG:50", $service->getLowST( $application ) );
+	}
+
+	/** vss_id == 0 with a character org resolves that org's storyteller. */
+	public function testZeroVssIdWithCharacterOrgResolvesCharacterOrg(): void {
+		$service = $this->makeService();
+		$this->characterDAO->vss = 0;
+		$this->characterDAO->org = 30;
+
+		$application = new stdClass;
+		$application->character_id = 1;
+		$application->org_id = 0;
+
+		$this->assertSame( "ORG:30", $service->getLowST( $application ) );
+	}
+
+	/** vss_id == 0 with no character org falls back to the owning player's org. */
+	public function testZeroVssIdWithNoCharacterOrgFallsBackToPlayerOrg(): void {
+		$service = $this->makeService();
+		$this->characterDAO->vss = 0;
+		$this->characterDAO->org = 0;
+		$this->characterDAO->uid = 5;
+
+		$application = new stdClass;
+		$application->character_id = 1;
+		$application->org_id = 0;
+
+		$this->assertSame( "ORG:777", $service->getLowST( $application ) );
+	}
+
+	/** vss_id > 0 resolves the VSS's own storyteller. */
+	public function testPositiveVssIdResolvesVssStoryteller(): void {
+		$service = $this->makeService();
+		$this->characterDAO->vss = 7;
+
+		$application = new stdClass;
+		$application->character_id = 1;
+		$application->org_id = 0;
+
+		$this->assertSame( "VSS:7", $service->getLowST( $application ) );
+	}
+
+	/** An empty character_id skips the character branch and uses the org's parent org. */
+	public function testEmptyCharacterIdResolvesParentOrg(): void {
+		$service = $this->makeService();
+
+		$application = new stdClass;
+		$application->character_id = "";
+		$application->org_id = 5;
+
+		$this->assertSame( "ORG:1005", $service->getLowST( $application ) );
+	}
+}

--- a/tests/Unit/PaginationOffsetTest.php
+++ b/tests/Unit/PaginationOffsetTest.php
@@ -1,0 +1,57 @@
+<?php
+require_once 'include/pagination.inc';
+
+/**
+ * Unit tests for paginationOffset(), covering negative, zero, positive,
+ * and non-numeric inputs to confirm it always yields a non-negative int
+ * safe for a SQL LIMIT offset.
+ *
+ * @see paginationOffset()
+ */
+final class PaginationOffsetTest extends \PHPUnit\Framework\TestCase {
+
+	/** A negative int offset is clamped to zero. */
+	public function testNegativeIntIsClampedToZero(): void {
+		$this->assertSame( 0, paginationOffset(-20) );
+	}
+
+	/** A negative numeric string offset is clamped to zero. */
+	public function testNegativeStringIsClampedToZero(): void {
+		$this->assertSame( 0, paginationOffset("-20") );
+	}
+
+	/** A zero int offset passes through unchanged. */
+	public function testZeroIntStaysZero(): void {
+		$this->assertSame( 0, paginationOffset(0) );
+	}
+
+	/** A zero numeric string offset passes through unchanged. */
+	public function testZeroStringStaysZero(): void {
+		$this->assertSame( 0, paginationOffset("0") );
+	}
+
+	/** A positive int offset passes through unchanged. */
+	public function testPositiveIntPassesThrough(): void {
+		$this->assertSame( 40, paginationOffset(40) );
+	}
+
+	/** A positive numeric string offset is cast to int. */
+	public function testPositiveStringIsCastToInt(): void {
+		$this->assertSame( 60, paginationOffset("60") );
+	}
+
+	/** A non-numeric string casts to zero and is clamped. */
+	public function testNonNumericStringClampsToZero(): void {
+		$this->assertSame( 0, paginationOffset("abc") );
+	}
+
+	/** A null offset casts to zero and is clamped. */
+	public function testNullClampsToZero(): void {
+		$this->assertSame( 0, paginationOffset(null) );
+	}
+
+	/** Another positive numeric string offset is cast to int. */
+	public function testAnotherPositiveStringIsCastToInt(): void {
+		$this->assertSame( 13, paginationOffset("13") );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * PHPUnit bootstrap for approvals_rewrite.
+ *
+ * Sets the working directory to the repo root so the application's cwd-relative
+ * `include_once("classes/...")` paths resolve when a test requires an app class.
+ * Unit tests inject stub doubles for every DAO, so neither the database nor
+ * `include/settings.inc` is loaded here — tests run fully offline.
+ *
+ * Each test file `require_once`s the specific app file it exercises (e.g.
+ * `require_once "classes/ApplicationService.php";`), keeping side-effectful
+ * includes out of tests that don't need them.
+ */
+
+// App code predates PHP 8.x deprecations; keep them out of the test signal but
+// still surface warnings/notices (phpunit.xml fails the run on those).
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+
+chdir(dirname(__DIR__));

--- a/tools/get-phpunit.ps1
+++ b/tools/get-phpunit.ps1
@@ -1,0 +1,10 @@
+# Fetch the PHPUnit phar used by this project's test suite.
+# The phar is gitignored (dev-only, never deployed to the web root); run this once
+# after cloning, then: php tools\phpunit.phar
+$ErrorActionPreference = 'Stop'
+$version = '11'
+$dest = Join-Path $PSScriptRoot 'phpunit.phar'
+$url = "https://phar.phpunit.de/phpunit-$version.phar"
+Write-Host "Downloading PHPUnit $version -> $dest"
+Invoke-WebRequest -Uri $url -OutFile $dest
+& php $dest --version

--- a/tools/get-phpunit.sh
+++ b/tools/get-phpunit.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Fetch the PHPUnit phar used by this project's test suite.
+# The phar is gitignored (dev-only, never deployed to the web root); run this once
+# after cloning, then: php tools/phpunit.phar
+set -euo pipefail
+VERSION="11"
+DEST="$(cd "$(dirname "$0")" && pwd)/phpunit.phar"
+URL="https://phar.phpunit.de/phpunit-${VERSION}.phar"
+echo "Downloading PHPUnit ${VERSION} -> ${DEST}"
+curl -fSL -o "$DEST" "$URL"
+chmod +x "$DEST"
+php "$DEST" --version


### PR DESCRIPTION
Addresses every issue found while reviewing the production PHP error logs, and stands up a real (composer-free) PHPUnit test framework.

## Fixes
| Sev | Issue | Fix |
|---|---|---|
| 🔴 | `LIMIT -20, 20` fatal (500 on User Listing) | `paginationOffset()` clamp in UserService/UserList/UserFeedback/UserFeedbackShowThread; fixed UserList next-link math (`-1`→`+1`) |
| 🟠 | `getLowST()` used undefined `$vss_id`/`$player` → wrong approval-email ST | Use `$character->vss_id` and `$userinfo['org_id']`; DocBlock added |
| 🟡 | `RevisionDAO::insert(&$revision)` by-ref notice (6 sites) | Drop the `&` (only sets `->id`) |
| 🟡 | `Undefined variable $changed` in AppDetails edit branch | Initialize before the mode chain; pass `implode(', ', $changed)` so empty renders `''` not `Array` |
| 🟡 | Audit log to non-writable hardcoded path (permission denied) | `__DIR__`-relative `vssmove.log` (2 files) |
| 🧹 | ~116 debug `error_log('Point N…')` lines/request | Stripped from index.php + session_start.inc |

## Test framework (dev-only, runtime untouched)
- PHPUnit 11 via a **gitignored** `tools/phpunit.phar` (fetch with `tools/get-phpunit.sh|.ps1`) — no composer, nothing new deployed to the web root.
- `phpunit.xml`, `tests/bootstrap.php` (offline; stub DAOs, no DB/settings), `tests/README.md`.
- New offline unit tests: `GetLowSTTest` (4 routing branches + org-only path), `PaginationOffsetTest` (clamp edge cases).

## Verification
- `php tools/phpunit.phar` → **OK (14 tests, 14 assertions)**.
- `php -l` clean on all touched PHP files. (mcp IDE diagnostics not available in this env.)
- Existing `php tests/test_final_approval.php` integration script is unaffected (not in the unit suite; needs live DB).