### PR TITLE
fix: stop double-rendering line breaks and duplicate .cs wrappers in character sheets

### DIFF
--- a/DisplayCharacter.php
+++ b/DisplayCharacter.php
@@ -110,7 +110,7 @@
 			}
 			?>
 			<?php
-				echo("<div class=\"cs\" id=\"sheet-display\">".formatBlockText($character["character_sheet"])."</div>");
+				echo("<div id=\"sheet-display\">".formatBlockText($character["character_sheet"])."</div>");
 			?>
 		</td>
 	</tr>
@@ -118,9 +118,7 @@
 		<th colspan="7" align="center">Background</th>
 	</tr>
 	<tr>
-		<td colspan="7" align="left"><div class="cs">
-			<?php echo(formatBlockText($character["background"])); ?>
-		</div></td>
+		<td colspan="7" align="left"><?php echo(formatBlockText($character["background"])); ?></td>
 	</tr>
 <?php
 		 $db->query("select * from applications where character_id='$character[id]' order by status desc, id desc");

--- a/VSSDetails.php
+++ b/VSSDetails.php
@@ -143,7 +143,7 @@
 				$ThisVSS=$row["vss"];
 				$ThisVSS=formatBlockText($ThisVSS );
 			  $ThisVSS=str_replace("\"", "&quot;",$ThisVSS);
-				echo("<span class=\"cs\">$ThisVSS</span>");
+				echo($ThisVSS);
 		?>
 	  </td>
 	</tr>

--- a/VerifyApproval.php
+++ b/VerifyApproval.php
@@ -176,21 +176,9 @@ if ( !empty( $_POST['app_number'] ) ) {
 	  if ( $app_info["character_sheet"]=="" ) {
 			echo("<em>(None)</em>");
 		} else {
-			$ThisCS=$app_info["character_sheet"];
-			$ThisCS= str_replace(".&nbsp;",". ",
- 			  str_replace(":&nbsp;",": ",
-   			  str_replace(",&nbsp;", ", ",
-    				  str_replace(chr(9),"&nbsp;&nbsp;&nbsp;&nbsp; ",
-         				str_replace(" ", "&nbsp;",
-       					  str_replace( chr(13), "<br>", $ThisCS )
-       					)
-							)
-						)
-  				)
-  		  );
-		  $quot_ent = chr(38) . "quot;";
-		  $ThisCS=str_replace("\"", $quot_ent, $ThisCS);
-			echo("<span class=\"cs\">$ThisCS</span>");
+			$ThisCS = $app_info["character_sheet"];
+			$ThisCS = str_replace("\"", "&quot;", $ThisCS);
+			echo(formatBlockText($ThisCS));
 		}
 ?>
     </td>

--- a/db.inc
+++ b/db.inc
@@ -25,6 +25,7 @@ header( "Expires: -1" );
 
 include_once("include/ResultSet.class.php");
 include_once("include/Database.class.php");
+require_once("include/text_formatting.inc");
 
 // --- Early access whitelist support (simplest possible implementation) ---
 // Controlled entirely by $SETTINGS["EARLY_ACCESS_ENABLED"] (see settings.inc.example).
@@ -196,17 +197,6 @@ function activateUserPopups() {
 	$o .= "\t\$('a.userLink').tooltip({showURL:false,delay:0,track:true,bodyHandler:function(){return USER_TOOLTIPS[$(this).attr('userid')]}});\n";
 	$o .="});\n</script>";
 	return $o;
-}
-
-// Formats random free text that users enter into something vageuly readable
-// Accounting for HTML vagaries and without using the accursed <pre> tag.
-function formatBlockText( $text ) {
-	$formattedText = nl2br( $text );
-	$formattedText = str_replace("	", "&nbsp;&nbsp;", $formattedText );
-	$formattedText = str_replace(".&nbsp;", ". ", $formattedText);
-	$formattedText = str_replace(chr(9),"&nbsp;&nbsp;&nbsp;&nbsp; ", $formattedText);
-	$formattedText = str_replace(",&nbsp;", ", ", $formattedText);
-	return "<span class=\"cs\">".$formattedText."</span>";
 }
 
 function email_is_google($email){

--- a/include/text_formatting.inc
+++ b/include/text_formatting.inc
@@ -1,0 +1,39 @@
+<?php
+
+if ( ! function_exists('formatBlockText') ) {
+	/**
+	 * Renders a block of user-entered free text as a single `.cs`-styled
+	 * `<div>`, so character sheets, backgrounds, and similar long-form fields
+	 * stay readable without resorting to the `<pre>` tag.
+	 *
+	 * Line breaks are left as raw `\n`/`\r\n` in the output rather than being
+	 * converted to `<br>` — the `.cs` CSS class renders with
+	 * `white-space: pre-wrap`, which already turns those characters into
+	 * visible line breaks in the browser. Injecting `<br>` as well as keeping
+	 * the original newline would double every line break.
+	 *
+	 * The returned string is wrapped in its own `<div class="cs">...</div>`,
+	 * so this is the single place that applies the `.cs` treatment — callers
+	 * must not additionally wrap the result in their own `.cs` container, or
+	 * the padded `.cs` background will be applied twice and bleed across
+	 * wrapped lines.
+	 *
+	 * @param $text Untrusted free text as entered by a user (e.g. a
+	 *              character sheet, background, or VSS body). May contain
+	 *              tabs, raw newlines, and arbitrary punctuation.
+	 * @return The text with tabs converted to non-breaking spaces and minor
+	 *         punctuation-spacing cleanup applied, wrapped in a single
+	 *         `<div class="cs">...</div>`.
+	 *
+	 * @example
+	 *   formatBlockText("Line one\nLine two.  Trailing.");
+	 *   // => "<div class=\"cs\">Line one\nLine two. Trailing.</div>"
+	 */
+	function formatBlockText( $text ) {
+		$formattedText = str_replace("	", "&nbsp;&nbsp;", $text );
+		$formattedText = str_replace(".&nbsp;", ". ", $formattedText);
+		$formattedText = str_replace(chr(9),"&nbsp;&nbsp;&nbsp;&nbsp; ", $formattedText);
+		$formattedText = str_replace(",&nbsp;", ", ", $formattedText);
+		return "<div class=\"cs\">".$formattedText."</div>";
+	}
+}

--- a/tests/Unit/FormatBlockTextTest.php
+++ b/tests/Unit/FormatBlockTextTest.php
@@ -1,0 +1,61 @@
+<?php
+require_once 'include/text_formatting.inc';
+
+/**
+ * Unit tests for formatBlockText(), covering the line-break-doubling
+ * regression (raw newlines must not also be converted to `<br>`) and the
+ * double-`.cs`-wrapper regression (the function must be the sole source of
+ * the `.cs` container), plus its existing tab/punctuation-spacing behavior.
+ *
+ * @see formatBlockText()
+ */
+final class FormatBlockTextTest extends \PHPUnit\Framework\TestCase {
+
+	/** A single `\n` passes through unconverted; no `<br>` is injected. */
+	public function testSingleNewlineProducesNoBrTag(): void {
+		$result = formatBlockText("Line one\nLine two");
+		$this->assertStringNotContainsString("<br", $result);
+		$this->assertStringContainsString("Line one\nLine two", $result);
+	}
+
+	/** A `\r\n` passes through unchanged, not duplicated or converted. */
+	public function testWindowsLineEndingPassesThroughUnchanged(): void {
+		$result = formatBlockText("Line one\r\nLine two");
+		$this->assertStringNotContainsString("<br", $result);
+		$this->assertStringContainsString("Line one\r\nLine two", $result);
+	}
+
+	/** The output is wrapped in exactly one `.cs` div, not nested. */
+	public function testOutputIsWrappedInExactlyOneCsDiv(): void {
+		$result = formatBlockText("Some text");
+		$this->assertStringStartsWith('<div class="cs">', $result);
+		$this->assertStringEndsWith('</div>', $result);
+
+		$inner = substr( $result, strlen('<div class="cs">'), -strlen('</div>') );
+		$this->assertStringNotContainsString('class="cs"', $inner);
+	}
+
+	/**
+	 * A literal tab character becomes two non-breaking spaces. (The later
+	 * chr(9)-based replacement never fires: this first replacement already
+	 * consumes every tab in the string, an existing quirk this test pins
+	 * down rather than "fixes".)
+	 */
+	public function testTabIsConvertedToNonBreakingSpaces(): void {
+		$result = formatBlockText("a\tb");
+		$this->assertStringContainsString("a&nbsp;&nbsp;b", $result);
+	}
+
+	/** A period followed by a non-breaking space (from tab conversion) collapses to a plain space. */
+	public function testPeriodBeforeNonBreakingSpaceCollapsesToPlainSpace(): void {
+		$result = formatBlockText("End.\tNext");
+		// The leading "\t" first becomes "&nbsp;&nbsp;", then ".&nbsp;" collapses to ". ".
+		$this->assertStringContainsString("End. &nbsp;Next", $result);
+	}
+
+	/** A comma followed by a non-breaking space (from tab conversion) collapses to a plain space. */
+	public function testCommaBeforeNonBreakingSpaceCollapsesToPlainSpace(): void {
+		$result = formatBlockText("List,\tItem");
+		$this->assertStringContainsString("List, &nbsp;Item", $result);
+	}
+}


### PR DESCRIPTION
## Summary
- `formatBlockText()` ran `nl2br()` while its `.cs` CSS class also sets `white-space: pre-wrap`, so every real line break rendered twice — producing the large gaps reported on character 36363's [DisplayCharacter.php](DisplayCharacter.php?char_id=36363) page.
- It also wrapped its output in an inline `<span class="cs">`, while several callers additionally wrapped that in their own `.cs` container (div-in-span or span-in-span). Because `.cs` carries vertical padding + a background, applying it twice to a multi-line-wrapping inline element bled the background across line boundaries — the "partially covered text" effect.
- Extracted `formatBlockText()` into `include/text_formatting.inc` (following the existing `paginationOffset()` precedent) so it's independently unit-testable, dropped the `nl2br()` call, and switched its wrapper to a block-level `<div class="cs">` — now the single authoritative place `.cs` is applied.
- Updated `DisplayCharacter.php`, `VSSDetails.php`, and `VerifyApproval.php` to stop double-wrapping; `VerifyApproval.php`'s duplicated hand-rolled formatting logic (same bug, reimplemented) is replaced with a call to the shared helper.

## Test plan
- [x] New `tests/Unit/FormatBlockTextTest.php` (6 tests) — full suite passes: `OK (20 tests, 24 assertions)`
- [x] `php -l` clean on all touched/created files
- [x] Visually verified against character 36363's real production background text (fetched raw via `mysql --raw`, cross-checked byte-for-byte against `HEX(SUBSTRING(...))`): before showed doubled blank-line gaps and garbled overlapping text bleed; after renders clean single-spacing matching the source document's actual paragraph breaks, no overlap
- [x] Confirmed the `templates/*.html` Smarty `|formatBlockText` usages (live in `AppDetails.php` / `CommentShowThreads.php`) have no `.cs`-wrapping containers, so they're unaffected/incidentally fixed by the same change