### PR TITLE
fix: stop MoveCharacter's two VSS pickers from silently overriding each other

### DIFF
--- a/MoveCharacter.php
+++ b/MoveCharacter.php
@@ -80,16 +80,17 @@
 		<td align="center">
 			<select name="localvss_id" size="20">
 <?php
+print( "<option value=\"\">-- Not Selected --</option>" );
 foreach( $localorgs as $localrow ) {
   $thisid= -$localrow["id"];
   $thisextratext="";
   if ( $thisid==$character->vss_id and $thisid!="" ) {
-    $selectedtext=" Selected";
+    $currenttext=" (current)";
 		$character->vss_id = "";
   } else {
-  	$selectedtext="";
+  	$currenttext="";
   }
-  print( "<option value=\"$thisid\" $selectedtext>" );
+  print( "<option value=\"$thisid\">" );
   if( $localrow["org_name"] != "" ) {
     print( "{$localrow["org_name"]} " );
   } else {
@@ -107,7 +108,7 @@ foreach( $localorgs as $localrow ) {
   if ( isset($localrow["storyteller_name"]) && $localrow["storyteller_name"]!="" ) {
     print( " ({$localrow['storyteller_name']})\n" );
   }
-  print( "</option>" );
+  print( "$currenttext</option>" );
 
 }
 
@@ -115,12 +116,12 @@ foreach ( $localvsss as $localrow ) {
   $thisid=$localrow["id"];
   $thisextratext="";
   if ( $thisid==$character->vss_id and $thisid!="" ) {
-    $selectedtext=" Selected";
+    $currenttext=" (current)";
 		$character->vss_id = "";
   } else {
-  	$selectedtext="";
+  	$currenttext="";
   }
-  print( "<option value=\"$thisid\" $selectedtext>" );
+  print( "<option value=\"$thisid\">" );
   if( $localrow["org_name"] != "" ) {
     print( "$localrow[org_name] " );
   } else {
@@ -143,7 +144,7 @@ foreach ( $localvsss as $localrow ) {
   if ( isset($localrow["storyteller_name"]) && $localrow["storyteller_name"]!="" ) {
     print( " 	 ($localrow[storyteller_name])\n" );
   }
-  print( "</option>" );
+  print( "$currenttext</option>" );
 
 }
 ?>
@@ -153,15 +154,16 @@ foreach ( $localvsss as $localrow ) {
 		<td align="center">
 			<select name="totalvss_id" size="20">
 <?php
+print( "<option value=\"\">-- Not Selected --</option>" );
 foreach ( $totalvsss as $totalrow ) {
   $thisid=$totalrow["id"];
   $thisextratext="";
   if ( $thisid==$character->vss_id and $thisid!="" ) {
-    $selectedtext=" Selected";
+    $currenttext=" (current)";
   } else {
-  	$selectedtext="";
+  	$currenttext="";
   }
-  print( "<option value=\"$thisid\" $selectedtext>" );
+  print( "<option value=\"$thisid\">" );
   if( $totalrow["org_name"] != "" ) {
     print( "$totalrow[org_name] " );
   } else {
@@ -183,7 +185,7 @@ foreach ( $totalvsss as $totalrow ) {
   if ( isset($totalrow["storyteller_name"]) && $totalrow["storyteller_name"]!="" ) {
     print( " 	 ($totalrow[storyteller_name])\n" );
 	}
-  print( "</option>\n" );
+  print( "$currenttext</option>\n" );
 }
 ?>
 		 	</select>

--- a/MoveCharacter2.php
+++ b/MoveCharacter2.php
@@ -8,9 +8,11 @@
     $vss_id = $_POST['totalvss_id'];
   }
 
-  $db->query("SELECT c.*, u.id AS player_id FROM characters c ".
-             "LEFT JOIN users u ON u.id = c.user_id ".
-             "WHERE c.id=" . $_POST['char_id']);
+  $query = "SELECT c.*, u.id AS player_id FROM characters c ".
+           "LEFT JOIN users u ON u.id = c.user_id ".
+           "WHERE c.id=?";
+  $params = [ $_POST['char_id'] ];
+  $db->query($query, $params);
   if ( $character = $db->nextRow() ) {
   	if($character['player_id'] == 0)
   	{


### PR DESCRIPTION
## Summary
- `MoveCharacter.php` renders two separate `<select>` boxes ("Local VSSs" / "All VSSs") in one form, and marked whichever option matched the character's *current* `vss_id`/org as HTML `selected` in either list. A single-select `<select>` always resubmits its `selected` option even when the player never clicks inside that box — so leaving one box untouched while picking a real value only in the other still sent the untouched box's stale current-value.
- `MoveCharacter2.php` treats a non-empty `localvss_id` as always taking precedence over `totalvss_id`, so that stale resubmitted value silently overrode the player's actual selection. When the stale value matched the character's existing `vss_id`, the resulting `UPDATE` was a same-value no-op — no error shown, VSS visibly unchanged.
- Reported against character 36368 ("Lucy Foster"): player selected VSS "Still Waters Run Deep" in the All VSSs box, left Local VSSs untouched (which had her current org pre-selected), submitted, and nothing changed.
- Fix: add a blank `-- Not Selected --` placeholder as the default option in both `<select>`s, and replace the `selected`-attribute marking of the current value with a plain `" (current)"` text label — so neither box auto-submits a value unless the player actually clicks an option in it. `MoveCharacter2.php`'s existing non-empty-wins precedence logic needed no changes once both boxes can genuinely represent "nothing chosen here."
- Also parameterized a raw string-concatenated `char_id` in `MoveCharacter2.php`'s character lookup query, matching the parameterized style already used later in the same file.

## Test plan
- [x] `php -l` clean on both files
- [x] Verified against a throwaway copy of the app pointed at the real production DB (not the live deployed files): rendered HTML confirmed no option carries `selected` except the implicit blank default, and the character's current value now shows as "(current)" text instead
- [x] Simulated the real form POST a player would send (`localvss_id=""`, `totalvss_id="1312"`) — confirmed the character's `vss_id` correctly updates
- [x] Simulated submitting both boxes blank — confirmed no database mutation occurs (falls through to the existing "require VSS" error path)
- [x] Reverted the test character's data back to its original state afterward so the actual reassignment happens through the fixed UI, not this PR