### PR TITLE
fix: stop VSSDetails.php from corrupting its own .cs wrapper

### DIFF
--- a/MoveCharacter2.php
+++ b/MoveCharacter2.php
@@ -1,12 +1,11 @@
 <?php
   include_once("db.inc");
+  require_once("include/vss_selection.inc");
 
-  $vss_id = 0;
-  if ( isset($_POST['localvss_id']) && $_POST['localvss_id'] != "" ) {
-    $vss_id = $_POST['localvss_id'];
-  } elseif ( isset($_POST['totalvss_id']) && $_POST['totalvss_id'] != "" ) {
-    $vss_id = $_POST['totalvss_id'];
-  }
+  $vss_id = resolveVssSelection(
+    isset($_POST['localvss_id']) ? $_POST['localvss_id'] : "",
+    isset($_POST['totalvss_id']) ? $_POST['totalvss_id'] : ""
+  );
 
   $query = "SELECT c.*, u.id AS player_id FROM characters c ".
            "LEFT JOIN users u ON u.id = c.user_id ".

--- a/VSSDetails.php
+++ b/VSSDetails.php
@@ -15,6 +15,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <link href="anathema.css" type='text/css' rel='stylesheet'>
   <title><?php echo $pagetitle?></title>
 	<script type="text/javascript">
@@ -142,7 +143,6 @@
 		<?php
 				$ThisVSS=$row["vss"];
 				$ThisVSS=formatBlockText($ThisVSS );
-			  $ThisVSS=str_replace("\"", "&quot;",$ThisVSS);
 				echo($ThisVSS);
 		?>
 	  </td>

--- a/VerifyApproval.php
+++ b/VerifyApproval.php
@@ -177,7 +177,6 @@ if ( !empty( $_POST['app_number'] ) ) {
 			echo("<em>(None)</em>");
 		} else {
 			$ThisCS = $app_info["character_sheet"];
-			$ThisCS = str_replace("\"", "&quot;", $ThisCS);
 			echo(formatBlockText($ThisCS));
 		}
 ?>

--- a/include/vss_selection.inc
+++ b/include/vss_selection.inc
@@ -1,0 +1,38 @@
+<?php
+
+if ( ! function_exists('resolveVssSelection') ) {
+	/**
+	 * Picks which of the two VSS-selection form fields (a local-org VSS
+	 * dropdown vs. a total-org VSS dropdown) should decide the character's
+	 * new VSS, since MoveCharacter.php submits both but only one is ever
+	 * meant to be honored.
+	 *
+	 * The local selection takes precedence over the total selection
+	 * whenever it was actually chosen; the total selection is used only
+	 * when the local one is empty. When neither field carries a real
+	 * selection, no VSS was chosen.
+	 *
+	 * @param $localvss_id The submitted `localvss_id` form value. An empty
+	 *                      string means the local dropdown was left
+	 *                      untouched (no selection made there).
+	 * @param $totalvss_id The submitted `totalvss_id` form value. An empty
+	 *                      string means the total dropdown was left
+	 *                      untouched (no selection made there).
+	 * @return The chosen VSS id (whichever field supplied it), or 0 when
+	 *         neither field had a real selection.
+	 *
+	 * @example
+	 *   resolveVssSelection("", "1312");     // => "1312" (total box wins when local is untouched)
+	 *   resolveVssSelection("-995", "");     // => "-995" (local box wins when total is untouched)
+	 *   resolveVssSelection("", "");         // => 0      (neither chosen)
+	 *   resolveVssSelection("-995", "1312"); // => "-995" (local takes precedence when both are set)
+	 */
+	function resolveVssSelection( $localvss_id, $totalvss_id ) {
+		if ( $localvss_id != "" ) {
+			return $localvss_id;
+		} elseif ( $totalvss_id != "" ) {
+			return $totalvss_id;
+		}
+		return 0;
+	}
+}

--- a/tests/Unit/ResolveVssSelectionTest.php
+++ b/tests/Unit/ResolveVssSelectionTest.php
@@ -1,0 +1,32 @@
+<?php
+require_once 'include/vss_selection.inc';
+
+/**
+ * Unit tests for resolveVssSelection(), covering the local-vs-total VSS
+ * dropdown precedence rule, including the exact "local blank, total set"
+ * scenario that caused a real production bug when this logic was inline.
+ *
+ * @see resolveVssSelection()
+ */
+final class ResolveVssSelectionTest extends \PHPUnit\Framework\TestCase {
+
+	/** When local is blank and total is set, the total selection is used. */
+	public function testBlankLocalUsesTotal(): void {
+		$this->assertSame( "1312", resolveVssSelection( "", "1312" ) );
+	}
+
+	/** When local is set and total is blank, the local selection is used. */
+	public function testSetLocalWithBlankTotalUsesLocal(): void {
+		$this->assertSame( "-995", resolveVssSelection( "-995", "" ) );
+	}
+
+	/** When both fields are blank, no VSS was chosen. */
+	public function testBothBlankReturnsZero(): void {
+		$this->assertSame( 0, resolveVssSelection( "", "" ) );
+	}
+
+	/** When both fields are set, the local selection takes precedence. */
+	public function testBothSetLocalTakesPrecedence(): void {
+		$this->assertSame( "-995", resolveVssSelection( "-995", "1312" ) );
+	}
+}


### PR DESCRIPTION
## Summary
- `VSSDetails.php` ran `str_replace('"', '&quot;', $ThisVSS)` *after* `formatBlockText()` had already wrapped the text in `<div class="cs">`, corrupting the div's own quotes into `class=&quot;cs&quot;` and breaking the `.cs` CSS match entirely. Without `.cs`'s `white-space: pre-wrap`, real line breaks in the text collapsed under normal HTML whitespace rules, rendering as one giant unbroken block — reported on [VSSDetails.php?id=1316](VSSDetails.php?id=1316).
- This was a regression from the earlier character-sheet-rendering fix (#17): before that fix, a second, correctly-quoted wrapper span added *after* the escaping masked the corruption of the first. Removing that redundant wrapper (correctly, to fix a different bug) left the corrupted wrapper as the only one.
- The escaping was unnecessary to begin with — literal `"` in HTML text content needs no escaping — so it's deleted rather than reordered. Removed the same unnecessary step from `VerifyApproval.php` too; it wasn't broken (correct order there), but it's the same latent hazard that just caused this regression elsewhere.
- Added the missing `<meta charset="UTF-8">` to `VSSDetails.php`'s hand-rolled `<head>` (it builds its own standalone HTML document instead of going through the shared header, and was missing the tag every other page gets).
- Audited every other `formatBlockText()` call site and every other large free-text display path in the app (Plotkits, Mechanics, Events, FAQ, UserFeedback, Comments, ST Instructions, Org/Venue admin, Character Census) — confirmed no other instance of either bug pattern (escape-after-wrap, or missing newline handling entirely).
- Extracted `MoveCharacter2.php`'s VSS-selection precedence logic into a tested pure function (`include/vss_selection.inc` / `resolveVssSelection()`), closing a test-coverage gap from the prior `MoveCharacter` fix (#18) that had no automated regression test for the exact scenario that caused that production bug.

## Note on the "?ike ?ia" / "Nu?uanu" mojibake also visible on VSS 1316
Confirmed this is **already-corrupted data**, not a display bug — the byte between "Nu" and "uanu" is a literal `?` (0x3F) in the database, not a decoding artifact. Every text column in this schema is `latin1` (except one newer table), which can't represent the Hawaiian ʻokina; it was silently substituted with `?` at write time and that original character is permanently gone. A `latin1`→`utf8mb4` schema + connection migration to stop *further* loss (this doesn't affect already-corrupted rows) is planned as a separate, explicitly-confirmed step, since it touches every table in the production database.

## Test plan
- [x] `php tools/phpunit.phar` → `OK (24 tests, 28 assertions)`, including 4 new `ResolveVssSelectionTest` cases (covering the exact regression scenario) plus the existing suite
- [x] `php -l` clean on all 5 touched/created files
- [x] Verified against a throwaway copy of the app pointed at the real production DB (not the live deployed files): `class="cs"` now renders intact, and a full-page screenshot of VSS 1316 confirms proper paragraph structure matching the source document (headers, timeline entries, etc. all correctly separated) instead of one unbroken block