### PR TITLE
chore: migrate database from latin1 to utf8mb4

### DIFF
--- a/include/Database.class.php
+++ b/include/Database.class.php
@@ -53,9 +53,11 @@ class Database {
         die("<pre>" . $errMsg . "</pre>");
     }
 
-    // Force latin1 charset to match database collation
-    if (!mysqli_set_charset($this->dbh, 'latin1')) {
-        $errMsg = "CRITICAL: mysqli_set_charset('latin1') failed: " . mysqli_error($this->dbh);
+    // Force utf8mb4 charset to match database collation (all tables migrated
+    // from latin1 2026-09-01; must stay in lockstep with the schema charset —
+    // see the utf8mb4 migration in sql/ for context).
+    if (!mysqli_set_charset($this->dbh, 'utf8mb4')) {
+        $errMsg = "CRITICAL: mysqli_set_charset('utf8mb4') failed: " . mysqli_error($this->dbh);
         error_log("Database::__construct – " . $errMsg);
         die("<pre>" . $errMsg . "</pre>");
     }

--- a/sql/migrate_latin1_to_utf8mb4.sql
+++ b/sql/migrate_latin1_to_utf8mb4.sql
@@ -1,0 +1,60 @@
+-- Migrate every latin1 table in approvals_2017 to utf8mb4.
+--
+-- Context: every text column in this schema was latin1, which cannot
+-- represent most non-Latin-1 Unicode characters (e.g. the Hawaiian ʻokina).
+-- Characters outside latin1's range were being silently replaced with "?"
+-- on write (permanent, unrecoverable data loss), and even correctly-stored
+-- latin1 high-byte characters were being mis-served to browsers that
+-- declare <meta charset="UTF-8"> (recoverable mojibake, fixed by this
+-- migration). See the "?ike ?ia" / "Nu?uanu" mojibake on VSSDetails.php
+-- (VSS id 1316) for the reported symptom.
+--
+-- `CONVERT TO CHARACTER SET` transcodes each column's existing bytes from
+-- their current (correctly-declared) latin1 codepoints into the equivalent
+-- utf8mb4 bytes -- it does not blindly reinterpret bytes, so genuinely
+-- latin1 content (plain ASCII, correctly-stored accented characters)
+-- round-trips correctly. It cannot and does not restore already-"?"
+-- -substituted characters, since that original codepoint no longer exists
+-- anywhere in the data.
+--
+-- MUST be run before (not after) include/Database.class.php's connection
+-- charset is switched from 'latin1' to 'utf8mb4' -- otherwise a
+-- utf8mb4-speaking connection would immediately start corrupting
+-- still-latin1 tables. Take a full mysqldump backup of approvals_2017
+-- before running this.
+--
+-- portal_user_cache is intentionally excluded -- already utf8mb4.
+
+ALTER TABLE activity_log CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE applications CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE cam_userdata CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE categories CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE character_sheet_versions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE character_subtypes CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE characters CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE comments CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE custom_mechanics_search CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE earnedxp CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE events CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE faq CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE feedback CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE fullqueries CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE gsa_comments CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE gsalist CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE instructions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE mechanics CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE old_applications CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE old_characters CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE old_users CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE organizations CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE plotkits CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE preferences CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE revisions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE revisions_bak CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE sessions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE spentxp CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE temptable CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE user_prefs CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE users CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE venues CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE vsss CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary
- Every table in `approvals_2017` except `portal_user_cache` is `latin1`, which cannot represent most non-Latin-1 Unicode (e.g. the Hawaiian 'okina). Characters outside latin1's range were silently replaced with `?` on write (permanent, unrecoverable data loss) -- the "Nu?uanu" mojibake on VSSDetails.php (VSS id 1316) is this. Even correctly-stored latin1 high-byte characters are currently being mis-served to browsers that declare `<meta charset="UTF-8">` (recoverable mojibake).
- Adds `sql/migrate_latin1_to_utf8mb4.sql` -- `ALTER TABLE ... CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci` for all 33 affected tables. This is ops/DBA tooling, run once against production directly ahead of merging this PR -- not something the app executes.
- Switches `include/Database.class.php`'s connection charset from `latin1` to `utf8mb4` to match.
- **These two changes must land together**: the schema migration runs first (backup taken beforehand), then this PR merges/deploys immediately after -- never the other way around, and not with a long gap, since a mismatched connection/schema charset would corrupt data either direction.
- Does **not** restore already-`?`-substituted characters -- that original data no longer exists anywhere in the database.

## Test plan
- [ ] Full `mysqldump` backup of `approvals_2017` taken immediately before running the migration SQL
- [ ] `sql/migrate_latin1_to_utf8mb4.sql` run against production; confirm all 33 tables report `utf8mb4` in `information_schema.columns`
- [ ] This PR merged and deployed immediately after (`git pull`), so the connection charset switch lands right after the schema conversion
- [ ] Spot-check a previously-mojibake'd but not fully "?"-lost row displays correctly post-migration; confirm already-corrupted `?` rows are unchanged (expected, not a regression)
- [ ] Spot-check normal app pages (a character, a VSS, an application) still load correctly post-migration