### PR TITLE
fix: remove now-harmful manual iconv() charset conversion in VSSDAO

### DIFF
--- a/classes/VSSDAO.class.php
+++ b/classes/VSSDAO.class.php
@@ -54,12 +54,12 @@ class VSSDAO {
 	function readByID( $vss_id ) {
 		$vss = $this->readVSSsByID( array($vss_id) );
 		return new VSS(
-			iconv('ISO-8859-1', 'UTF-8', $vss[0]['name']),
-			iconv('ISO-8859-1', 'UTF-8', $vss[0]['email']),
+			$vss[0]['name'],
+			$vss[0]['email'],
 			$vss[0]['venue_id'],
 			$vss[0]['storyteller_id'],
 			$vss[0]['org_id'],
-			iconv('ISO-8859-1', 'UTF-8', $vss[0]['vss']),
+			$vss[0]['vss'],
 			$vss[0]['id']
 		);
 	}
@@ -124,9 +124,9 @@ class VSSDAO {
 			$vss->venue_id,
 			$vss->organization_id,
 			$vss->storyteller_id,
-			iconv('UTF-8', 'ISO-8859-1//TRANSLIT', $vss->name),
-			iconv('UTF-8', 'ISO-8859-1//TRANSLIT', $vss->email),
-			iconv('UTF-8', 'ISO-8859-1//TRANSLIT', $vss->vss),
+			$vss->name,
+			$vss->email,
+			$vss->vss,
 			time()
 		] );
 		$vss->id = $this->db->getInsertId();


### PR DESCRIPTION
## Summary
- `VSSDAO::readByID()` and `VSSDAO::insert()` manually converted between ISO-8859-1 and UTF-8 -- necessary when the DB connection and `vsss` table were `latin1`, but since today's latin1->utf8mb4 migration (#20) mysqli already returns/accepts correct UTF-8 directly. Found while reviewing this week's error logs.
- `readByID()` told `iconv()` to treat already-correct UTF-8 as ISO-8859-1, double-encoding any multi-byte character on every read. Confirmed live against VSS 1259 ("Discord in Harmony"): the old code produced `â` where the database actually has `"`. This corrupts the VSS name/email/description shown on the Application Details page on every view.
- `insert()` -- the live "Add VSS" handler, `ModifyVSSListAddVSS.php` -- transliterated UTF-8 down to ISO-8859-1 before storing, silently destroying non-Latin-1 characters in every new VSS. Confirmed live that inserting `café` / the Hawaiian ʻokina produced `caf` and a literal `?` in the stored row -- i.e. permanent data loss for any new VSS created since the migration deployed.
- Removes all six `iconv()` calls; the strings now pass through unchanged. Confirmed via repo-wide grep these were the only `iconv()` calls left in the codebase.

## Test plan
- [x] `php -l classes/VSSDAO.class.php`
- [x] Verified against a throwaway copy of the app pointed at the real production DB (not the live deployed files), comparing the old and fixed `readByID()` side by side against VSS 1259: old produced `â` (corrupted), fixed matches the raw DB truth (`"`) exactly
- [x] Verified `insert()` the same way: inserted a test VSS containing `café` and the Hawaiian ʻokina through both the old and fixed code paths -- old truncated/corrupted it (`caf`, literal `?`), fixed preserved it byte-for-byte; test rows deleted after verification