### PR TITLE
fix: VSSDAO returns null instead of a garbage object when a VSS isn't found

### DIFF
--- a/AppDetails.php
+++ b/AppDetails.php
@@ -211,7 +211,14 @@ if( $mode == 'doAdd' || $mode == 'doEdit' ) {
 		$app_info->org_id = $_GET['apporg_id'];
 	} elseif ( is_object( $app_info->character ) && is_numeric($app_info->character->vss_id) && $app_info->character->vss_id > 0 ) {
 		$app_info->character->vss = $vssDAO->readByID( $app_info->character->vss_id );
-		$app_info->org_id = $app_info->character->vss->organization_id;
+		if( is_object( $app_info->character->vss ) ) {
+			$app_info->org_id = $app_info->character->vss->organization_id;
+		} elseif( is_numeric( $app_info->character->org_id ) && $app_info->character->org_id > 0 ) {
+			$app_info->org_id = $app_info->character->org_id;
+		} else {
+			// Use the Org ID of the logged in user
+			$app_info->org_id = $_SESSION['org_id'];
+		}
 	} elseif ( is_object( $app_info->character ) && is_numeric($app_info->character->vss_id) && $app_info->character->vss_id < 0 ) {
 		$app_info->org_id = 0-$app_info->character->vss_id;
 	} elseif( is_object( $app_info->character ) && is_numeric( $app_info->character->org_id ) && $app_info->character->org_id > 0 ) {

--- a/AppDetailsTopSection.php
+++ b/AppDetailsTopSection.php
@@ -18,11 +18,16 @@ if( is_object( $app_info->character ) ) {
 		if( !is_object( $app_info->character->vss ) ) {
 			$app_info->character->vss = $vssDAO->readByID( $app_info->character->vss_id );
 		}
-		$storytellers[] = array(
-			'title' => 'VST',
-			'id'    => $app_info->character->vss->storyteller_id
-		);
-		$vss_org_id = $app_info->character->vss->organization_id;
+		if( is_object( $app_info->character->vss ) ) {
+			$storytellers[] = array(
+				'title' => 'VST',
+				'id'    => $app_info->character->vss->storyteller_id
+			);
+			$vss_org_id = $app_info->character->vss->organization_id;
+		} else {
+			$is_unassigned=true;
+			$vss_org_id = $app_info->org_id;
+		}
 	} elseif ( is_numeric($app_info->character->vss_id) && $app_info->character->vss_id < 0 ) {
 		$vss_org_id = 0-$app_info->character->vss_id;
 		$organization = $organizationDAO->readByID($vss_org_id);
@@ -162,7 +167,9 @@ if ( is_object( $app_info->character ) && strtolower($app_info->character->char_
 		if( !is_object( $app_info->character->vss ) ) {
 			$app_info->character->vss = $vssDAO->readByID( $app_info->character->vss_id );
 		}
-		$storyteller = $userDAO->getUserInfo($app_info->character->vss->storyteller_id);
+		if( is_object( $app_info->character->vss ) ) {
+			$storyteller = $userDAO->getUserInfo($app_info->character->vss->storyteller_id);
+		}
 	} elseif ( $app_info->character->vss_id < 0 ) {
 		$organization= $organizationDAO->readByID( 0-$character->vss_id );
 		$storyteller = $userDAO->getUserInfo( $organization->admin_user_id );

--- a/classes/VSSDAO.class.php
+++ b/classes/VSSDAO.class.php
@@ -48,11 +48,14 @@ class VSSDAO {
 
 	function readVSSByID( $id ) {
 		$vsss = $this->readVSSsByID( array($id) );
-		return $vsss[0];
+		return $vsss[0] ?? null;
 	}
 
 	function readByID( $vss_id ) {
 		$vss = $this->readVSSsByID( array($vss_id) );
+		if( count( $vss ) == 0 ) {
+			return null;
+		}
 		return new VSS(
 			$vss[0]['name'],
 			$vss[0]['email'],


### PR DESCRIPTION
## Summary
- `VSSDAO::readVSSsByID()` requires a VSS's parent organization *and* venue to both be `active=1` -- a VSS whose org or venue has since been deactivated (e.g. a local chapter closed) returns zero rows even though the id is still valid and still referenced by a character.
- `readByID()` then blindly indexed into the empty result (`$vss[0]['name']` etc.), producing "Undefined array key 0" warnings and constructing a `VSS` object where every property -- including `organization_id` -- ended up `null`.
- That `null` propagated silently through `AppDetailsTopSection.php` / `AppDetails.php` into `OrganizationDAO::readByID(null)`, which correctly returns an actual `null` (its own established not-found convention) -- and *that* `null` got dereferenced unguarded too, producing the "Attempt to read property on null" warnings seen in this week's production error log.
- Confirmed via live data: **120 active characters** currently reference a VSS under one of 10 closed local chapters within a single still-active venue, so this reproduces continuously in production, not as a rare edge case.
- Makes `VSSDAO::readByID()`/`readVSSByID()` follow the same not-found convention `OrganizationDAO::readByID()` already uses (return `null`), and updates the three real call sites to fall back exactly the way sibling branches in the same files already handle "no VSS assigned" -- reusing existing fallback logic rather than introducing new behavior. Not fatal today (PHP 8 warnings, not crashes) -- just log noise plus a broken/blank storyteller-affiliation box on the Application Details page for affected characters.
- Considered and rejected bulk-reassigning these 120 characters to a new VSS as an alternative -- the active VSS options in that venue are organized by region while the closed chapters were domain-level (ambiguous or nonexistent mapping for several regions), and more fundamentally it's the player's call to make via `MoveCharacter.php`, not something to script in bulk.

## Test plan
- [x] `php -l` clean on all three edited files
- [x] Verified against a throwaway copy of the app pointed at the real production DB (not the live deployed files): rendered a real affected application (character under the closed "Silver and Sin" chapter) -- the original warning cascade is completely gone, and the page renders a sensible fallback (falls back to the character's home org, so the storyteller escalation chain still populates)
- [x] Regression-checked a normal application with an active VSS -- renders identically, no new warnings