### PR TITLE
fix: char_dead checkbox warning and wrong property in AppDetails VSS check

### DIFF
--- a/AppDetails.php
+++ b/AppDetails.php
@@ -42,7 +42,7 @@ $app_info->venue = $venueDAO->readByID( $app_info->venue_id );
 $app_info->organization = $organizationDAO->readByID( $app_info->org_id );
 if( $app_info->character != null ) {
 	$app_info->character->venue = $venueDAO->readByID( $app_info->character->venue_id);
-	if( $app_info->character->vss > 0 ) {
+	if( $app_info->character->vss_id > 0 ) {
 		$app_info->character->vss = $vssDAO->readByID( $app_info->character->vss_id );
 	} elseif ( $app_info->character->vss_id < 0 ) {
 		$app_info->character->organization = $organizationDAO->readByID( 0 - $app_info->character->vss_id);

--- a/ModifyCharacterList4.php
+++ b/ModifyCharacterList4.php
@@ -9,7 +9,7 @@ $subtype = $_POST['SubType'];
 $character_sheet = $_POST['character_sheet'];
 $background = $_POST['Background'];
 $active = isset($_POST['Active']) && $_POST['Active'] ? "1" : "0";
-$char_dead = $_POST['char_dead'] ? "1" : "0";
+$char_dead = isset($_POST['char_dead']) && $_POST['char_dead'] ? "1" : "0";
 if ( $char_dead ) $active = 0;
 
 if ( isset($_POST["delete"]) ) {


### PR DESCRIPTION
## Summary
- `ModifyCharacterList4.php:12` read `$_POST['char_dead']` with no `isset()` check, unlike `$active` right above it -- HTML omits unchecked checkboxes from POST entirely, so unchecking "dead" and saving always triggered an "Undefined array key" warning. Mirrors the existing `Active` pattern one line up.
- `AppDetails.php:45` compared `->vss` (unset at that point) instead of `->vss_id` (used everywhere else, including the very next `elseif`) when deciding whether to eagerly fetch a character's VSS -- making that branch dead code (harmless today since `AppDetailsTopSection.php` has its own redundant fallback fetch, but wrong).
- Two small, unrelated one-line fixes, both matching an existing pattern already present one line away in the same file.
- (A third item from the same review -- stripping stray `?` characters left over from old latin1-era data loss -- was investigated and dropped: after excluding URL query strings, every remaining candidate turned out to be a real, correctly-used question mark from this app's character-creation templates, with no reliable way to distinguish real punctuation from lost characters by local text pattern. No data change made.)

## Test plan
- [x] `php -l` clean on both files
- [x] `ModifyCharacterList4.php`: simulated a POST without a `char_dead` key -- confirmed no warning, `$char_dead` resolves to `"0"`
- [x] `AppDetails.php`: verified against a real character with `vss_id > 0`, using the real deployed `VSSDAO`/`CharacterDAO` classes (not a copy) -- confirmed the branch now activates and correctly populates `$character->vss` via `readByID()` with no warnings