### PR TITLE
fix: correct portal_user_cache's collation mismatch breaking UserList.php

### DIFF
--- a/sql/add_portal_user_cache.sql
+++ b/sql/add_portal_user_cache.sql
@@ -3,6 +3,11 @@
 -- via oauth_callback.php. Data may be up to one login-cycle stale, which
 -- is acceptable for an admin-facing list; actual access is still gated by
 -- portal OAuth.
+--
+-- Explicit COLLATE utf8mb4_unicode_ci to match the rest of the schema
+-- (see sql/fix_portal_user_cache_collation.sql for the production fix
+-- this was missing until 2026-09-02, which caused ww_number join
+-- failures against `users`).
 CREATE TABLE IF NOT EXISTS portal_user_cache (
     ww_number             VARCHAR(20)  NOT NULL,
     first_name            VARCHAR(100) DEFAULT NULL,
@@ -15,4 +20,4 @@ CREATE TABLE IF NOT EXISTS portal_user_cache (
     INDEX idx_last_name  (last_name),
     INDEX idx_first_name (first_name),
     INDEX idx_expiry     (membership_expiration)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/sql/fix_portal_user_cache_collation.sql
+++ b/sql/fix_portal_user_cache_collation.sql
@@ -1,0 +1,25 @@
+-- Fix portal_user_cache's collation to match the rest of the schema.
+--
+-- portal_user_cache (sql/add_portal_user_cache.sql, added 2026-06-09) was
+-- created with CHARSET=utf8mb4 but no explicit COLLATE, so it silently
+-- picked up MySQL 8's server default utf8mb4_0900_ai_ci. The 2026-09-01
+-- latin1->utf8mb4 migration (sql/migrate_latin1_to_utf8mb4.sql) converted
+-- every other table -- including `users` -- to utf8mb4_unicode_ci, and its
+-- header comment incorrectly excluded portal_user_cache as "already
+-- utf8mb4" (true for charset, false for collation). The mismatch between
+-- users.ww_number (utf8mb4_unicode_ci) and portal_user_cache.ww_number
+-- (utf8mb4_0900_ai_ci) makes every `=` join between them throw "Illegal
+-- mix of collations" -- an uncaught mysqli_sql_exception on every load of
+-- UserList.php (services/UserService.class.php lines 23 and 49).
+--
+-- portal_user_cache is a fully disposable, derived cache -- repopulated
+-- nightly by sql/prefill_portal_user_cache.sql and incrementally on every
+-- OAuth login by oauth_callback.php -- so there is no unique data at risk.
+--
+-- CONVERT TO CHARACTER SET rewrites every char/varchar/text column in the
+-- table -- including the PRIMARY KEY (ww_number) and its indexes -- and
+-- rebuilds them as part of this single statement; no separate DROP/ADD
+-- INDEX step is needed. Identical pattern already run successfully
+-- against `users` and 32 other tables in migrate_latin1_to_utf8mb4.sql.
+
+ALTER TABLE portal_user_cache CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/utility/apply_portal_user_cache_collation_fix.php
+++ b/utility/apply_portal_user_cache_collation_fix.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * apply_portal_user_cache_collation_fix.php — One-time maintenance script that
+ * fixes the collation mismatch on `portal_user_cache.ww_number`.
+ *
+ * portal_user_cache (sql/add_portal_user_cache.sql) was created with
+ * CHARSET=utf8mb4 but no explicit COLLATE, so it silently picked up MySQL 8's
+ * server default utf8mb4_0900_ai_ci. The 2026-09-01 latin1->utf8mb4 migration
+ * (sql/migrate_latin1_to_utf8mb4.sql) converted `users` to utf8mb4_unicode_ci
+ * but skipped portal_user_cache, leaving `users.ww_number` and
+ * `portal_user_cache.ww_number` on different collations. Every `=` join
+ * between them (services/UserService.class.php lines 23 and 49) then throws
+ * an uncaught mysqli_sql_exception: "Illegal mix of collations
+ * (utf8mb4_unicode_ci,IMPLICIT) and (utf8mb4_0900_ai_ci,IMPLICIT)" — an
+ * uncaught exception on every load of UserList.php.
+ *
+ * This script executes the ALTER TABLE committed in
+ * sql/fix_portal_user_cache_collation.sql so the fix SQL lives in exactly one
+ * place, printing the ww_number collations on both tables before and after so
+ * the fix is independently verifiable rather than assumed. It is idempotent —
+ * re-running it after the fix has already been applied re-runs the (now
+ * no-op) ALTER and reports matching collations again — so it is safe to
+ * re-run if in doubt. CLI-only: refuses to run under a web SAPI so it cannot
+ * be triggered over HTTP.
+ *
+ * Per this repo's convention for one-off maintenance scripts (see
+ * utility/cleanup_org_encoding.php), this script stays in the repo after use
+ * as a record of the fix rather than being deleted.
+ *
+ * Usage (one-off, as user nta):
+ *   php /var/www/approvals_rewrite/utility/apply_portal_user_cache_collation_fix.php
+ */
+
+if (php_sapi_name() !== 'cli') {
+    http_response_code(403);
+    exit("Forbidden: CLI only\n");
+}
+
+// settings.inc references $_SERVER['SERVER_NAME']; provide it so CLI runs are warning-free.
+$_SERVER['SERVER_NAME'] = $_SERVER['SERVER_NAME'] ?? 'cli';
+
+$appRoot = dirname(__DIR__);
+chdir($appRoot);
+
+include_once($appRoot . '/include/settings.inc');
+include_once($appRoot . '/include/ResultSet.class.php');
+include_once($appRoot . '/include/Database.class.php');
+
+$sqlFile = $appRoot . '/sql/fix_portal_user_cache_collation.sql';
+$sqlRaw = file_get_contents($sqlFile);
+if ($sqlRaw === false || trim($sqlRaw) === '') {
+    fwrite(STDERR, date('c') . " apply_portal_user_cache_collation_fix: cannot read $sqlFile\n");
+    exit(1);
+}
+
+// Strip the leading `--` comment lines, keeping just the SQL statement.
+$lines = explode("\n", $sqlRaw);
+$sqlLines = array_filter($lines, function ($line) {
+    return trim($line) !== '' && substr(ltrim($line), 0, 2) !== '--';
+});
+$sql = trim(implode("\n", $sqlLines));
+if ($sql === '') {
+    fwrite(STDERR, date('c') . " apply_portal_user_cache_collation_fix: no SQL statement found in $sqlFile\n");
+    exit(1);
+}
+
+$db = new Database(
+    $SETTINGS['APPROVALS_SERVER'],
+    $SETTINGS['APPROVALS_USERNAME'],
+    $SETTINGS['APPROVALS_PASSWORD'],
+    $SETTINGS['APPROVALS_DATABASE']
+);
+$h = $db->dbh;
+
+/**
+ * Fetch the COLLATION_NAME of a given table/column from information_schema.
+ *
+ * @param resource|mysqli $h Open mysqli connection handle to query against.
+ * @param string $table Name of the table the column belongs to.
+ * @param string $column Name of the column to look up.
+ * @return string|null The column's collation (e.g. "utf8mb4_unicode_ci"), or
+ *                      null if the table/column doesn't exist.
+ */
+function get_column_collation($h, $table, $column) {
+    $table = mysqli_real_escape_string($h, $table);
+    $column = mysqli_real_escape_string($h, $column);
+    $result = mysqli_query($h,
+        "SELECT COLLATION_NAME FROM information_schema.columns " .
+        "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '$table' AND COLUMN_NAME = '$column'");
+    if (!$result) {
+        return null;
+    }
+    $row = mysqli_fetch_assoc($result);
+    return $row ? $row['COLLATION_NAME'] : null;
+}
+
+$usersBefore = get_column_collation($h, 'users', 'ww_number');
+$cacheBefore = get_column_collation($h, 'portal_user_cache', 'ww_number');
+printf("%s apply_portal_user_cache_collation_fix: BEFORE users.ww_number=%s portal_user_cache.ww_number=%s\n",
+    date('c'), $usersBefore, $cacheBefore);
+
+if (!mysqli_query($h, $sql)) {
+    fwrite(STDERR, date('c') . " apply_portal_user_cache_collation_fix: FAILED - " . mysqli_error($h) . "\n");
+    exit(1);
+}
+
+$usersAfter = get_column_collation($h, 'users', 'ww_number');
+$cacheAfter = get_column_collation($h, 'portal_user_cache', 'ww_number');
+printf("%s apply_portal_user_cache_collation_fix: AFTER users.ww_number=%s portal_user_cache.ww_number=%s\n",
+    date('c'), $usersAfter, $cacheAfter);
+
+if ($cacheAfter !== 'utf8mb4_unicode_ci') {
+    fwrite(STDERR, date('c') .
+        " apply_portal_user_cache_collation_fix: FAILED - portal_user_cache.ww_number collation is " .
+        "'$cacheAfter', expected 'utf8mb4_unicode_ci'\n");
+    exit(1);
+}
+
+printf("%s apply_portal_user_cache_collation_fix: OK\n", date('c'));
+exit(0);


### PR DESCRIPTION
## Summary
- `portal_user_cache.ww_number` was left on MySQL 8's default `utf8mb4_0900_ai_ci` when the table was created (no explicit `COLLATE`), while the 2026-09-01 latin1→utf8mb4 migration explicitly moved `users`/`organizations`/~30 other tables to `utf8mb4_unicode_ci` and mistakenly skipped this one as "already utf8mb4".
- Every `=` join between `users.ww_number` and `portal_user_cache.ww_number` in `services/UserService.class.php` (lines 23, 49) now throws an uncaught `mysqli_sql_exception: Illegal mix of collations`, fataling every load of `UserList.php` in production.
- Adds `sql/fix_portal_user_cache_collation.sql` (the corrective `ALTER TABLE ... CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`) and a one-off CLI runner, `utility/apply_portal_user_cache_collation_fix.php`, modeled on the existing `utility/refresh_portal_user_cache.php` pattern so the DB password stays server-side.
- Adds the missing explicit `COLLATE` to `sql/add_portal_user_cache.sql` so a future fresh/DR rebuild doesn't drift again.
- `sql/migrate_latin1_to_utf8mb4.sql` is left untouched as the historical record of what actually ran on 2026-09-01.

No PHP application behavior changes — this is a schema fix only. `portal_user_cache` is a fully disposable, derived cache (repopulated nightly and per-login), so there's no data-loss risk.

## Test plan
- [x] `php -l utility/apply_portal_user_cache_collation_fix.php` — no syntax errors
- [ ] After merge, `git pull` on the `approvals` host, then run `php utility/apply_portal_user_cache_collation_fix.php` once — its own before/after output must show `portal_user_cache.ww_number` as `utf8mb4_unicode_ci`
- [ ] `SELECT COUNT(*) FROM users u LEFT JOIN portal_user_cache puc ON u.ww_number = puc.ww_number;` succeeds without error
- [ ] `https://legacy.modernenigmasociety.org/UserList.php` loads the listing instead of a fatal error
- [ ] No new "Illegal mix of collations" entries in `/var/log/nginx/legacy_error.log` after the fix