### PR TITLE
fix: guard unauthenticated $_SESSION['user_id'] access on two character pages

### DIFF
--- a/ModifyCharacterList3.php
+++ b/ModifyCharacterList3.php
@@ -21,7 +21,7 @@
 
 	// JSON encode for JavaScript
 	$js_subtypes = json_encode($subtypes);
-  if ( $character["user_id"]!=$_SESSION['user_id'] &&
+  if ( $character["user_id"]!=($_SESSION['user_id'] ?? null) &&
   	 	 (empty($_SESSION['admin_vss_list']) ||!in_array( $character['vss_id'], $_SESSION['admin_vss_list'] )) &&
   	 	 (empty($_SESSION['admin_org_list']) || !in_array( -$character['vss_id'], $_SESSION['admin_org_list'] )) &&
   		 (empty($_SESSION['admin_org_list']) || !in_array( $character['org_id'], $_SESSION['admin_org_list'] )) ) {

--- a/ModifyCharacterXPList1.php
+++ b/ModifyCharacterXPList1.php
@@ -51,7 +51,7 @@ notes - text/varchar
   $db->query($query);
   $row=$db->nextRow();
   $character_user_id=$row["user_id"];
-  if ( $_SESSION['user_id']==$character_user_id ) {
+  if ( ($_SESSION['user_id'] ?? null)==$character_user_id ) {
   	$this_user=1;
   } else {
   	$this_user=0;


### PR DESCRIPTION
## Summary
- `ModifyCharacterXPList1.php:54` and `ModifyCharacterList3.php:24` each run their own ownership comparison against `$_SESSION['user_id']` *before* including `header.inc` (the actual login gate), so an anonymous request — mostly Googlebot, per production logs — hits the comparison before any gate has run and trips `Undefined array key "user_id"`.
- In both cases the missing-key-as-null behavior was already functionally correct (the comparison already behaved as if the value were `null`), so this change makes that explicit with `?? null` — same fix shape already used today in `classes/VSSDAO.class.php` (`return $vsss[0] ?? null;`) — with zero behavior change.
- Not touched (separate, out of scope): `ModifyCharacterList3.php:28`'s redirect is missing an `exit()`, but execution falls through to `header.inc`'s own correct gate/exit either way, so it's harmless today.

## Test plan
- [x] `php -l` on both edited files — no syntax errors
- [ ] After deploy, hit `ModifyCharacterXPList1.php?character_id=36355` and `ModifyCharacterList3.php?modify=36368` unauthenticated — expect normal redirect/response, not a fatal
- [ ] No new `Undefined array key "user_id"` entries for either file in `/var/log/nginx/legacy_error.log` after deploy