### PR TITLE
fix: silence Filter::mergeArray warning when required_approval arrives as a string

### DIFF
--- a/classes/Filter.php
+++ b/classes/Filter.php
@@ -46,7 +46,7 @@ class Filter {
 		if( array_key_exists( 'suborgs', $otherFilters ) ) { $changed=true; $this->suborgs = $otherFilters['suborgs']; }
 		if( array_key_exists( 'sortorder', $otherFilters ) ) { $changed=true; $this->sortorder = stripslashes($otherFilters['sortorder']); }
 		if( array_key_exists( 'inverted', $otherFilters ) ) { $changed=true; $this->inverted = $otherFilters['inverted']; }
-		if( array_key_exists( 'required_approval', $otherFilters ) && $otherFilters['required_approval'][0] != "" ) {
+		if( array_key_exists( 'required_approval', $otherFilters ) && ($otherFilters['required_approval'][0] ?? "") != "" ) {
 			$changed=true;
 			$this->required_approval = $otherFilters['required_approval'];
 		}


### PR DESCRIPTION
## Summary
- `app_main.php`'s sort-column links (Item/Number/Player/Venue/Required Approval/Status/Last Updated) rebuild the current filter query string by `implode(",", $value)`-ing array-valued filters; `required_approval` defaults to an empty array, so this produces a bare `required_approval=` in every sort link.
- Once followed, `$_GET['required_approval']` is a scalar empty string, not an array. `classes/Filter.php:49`'s `$otherFilters['required_approval'][0]` then indexes into that empty string, which PHP 8 warns on (`Uninitialized string offset 0`) — firing on nearly every click of a sort column on `app_main.php`, since `mergeArray($_GET)` runs on every request to that page.
- Fix: `($otherFilters['required_approval'][0] ?? "")` — `??` suppresses the warning whether the value is a missing key, empty array, or empty string, evaluating to `""` in all three cases, so the comparison and resulting behavior are unchanged. Warning-suppression only, no logic change.
- Not touched (separate, out of scope): the same `implode(",", $value)` flattening means a genuinely multi-selected `required_approval` filter would likely get silently dropped on a sort-link click, since it round-trips as a comma-joined scalar rather than an array. Real inconsistency, but not what's producing the logged warning.

## Test plan
- [x] `php -l` on the edited file — no syntax errors
- [ ] After deploy, click any column-sort link on `app_main.php` — page still sorts correctly, `required_approval` filter (if set) unaffected
- [ ] No new `Uninitialized string offset 0` entries from `classes/Filter.php` in `/var/log/nginx/legacy_error.log` after deploy