### PR TITLE
fix: guard null-organization warnings on MoveCharacter and session setup

### DIFF
--- a/MoveCharacter.php
+++ b/MoveCharacter.php
@@ -16,11 +16,11 @@
 
 	$localvsss = $vssDAO->readLocalVenueVSSs(
 		$character->venue_id,
-		$userOrganization->globe,
-		$userOrganization->nation,
-		$userOrganization->region,
-		$userOrganization->domain,
-		$userOrganization->chapter
+		$userOrganization->globe ?? null,
+		$userOrganization->nation ?? null,
+		$userOrganization->region ?? null,
+		$userOrganization->domain ?? null,
+		$userOrganization->chapter ?? null
 	);
 	for( $i=0; $i < count($localvsss); $i++ ) {
 		if (!empty($localvsss[$i]['storyteller_id'])) {
@@ -30,11 +30,11 @@
 	}
 
 	$localorgs = $organizationDAO->readLocalOrganizations(
-		$userOrganization->globe,
-		$userOrganization->nation,
-		$userOrganization->region,
-		$userOrganization->domain,
-		$userOrganization->chapter
+		$userOrganization->globe ?? null,
+		$userOrganization->nation ?? null,
+		$userOrganization->region ?? null,
+		$userOrganization->domain ?? null,
+		$userOrganization->chapter ?? null
 	);
 	for( $i = 0; $i < count( $localorgs); $i++ ) {
 		if (!empty($localorgs[$i]['storyteller_id'])) {

--- a/classes/UserInfoDAO.php
+++ b/classes/UserInfoDAO.php
@@ -214,7 +214,7 @@ function isMemberActive( $user_id ) {
 
 		$userInfo = $this->getUserInfo( $userID );
 		$positions = array();
-		if( $userInfo['super_user'] ) {
+		if( $userInfo['super_user'] ?? false ) {
 			$positions[] = "Super User";
 		}
 

--- a/session_setup.inc
+++ b/session_setup.inc
@@ -151,12 +151,12 @@ $_SESSION['admin_level'] = $admin_level;
 $_SESSION['admin_assistant'] = $top_final_organization != null && !$top_final_organization->isHigherThan($top_organization);
 if( $top_organization != null ) {
 	$_SESSION['obj_admin_level'] = $top_organization->getLevel();
-	$_SESSION['admin_level'] = $_SESSION['obj_admin_level']->organization_level;
+	$_SESSION['admin_level'] = $_SESSION['obj_admin_level']->organization_level ?? '';
 	$_SESSION['admin_org_id'] = $top_organization->id;
 }
 if( $top_final_organization != null ) {
 	$_SESSION['obj_max_final_authority_level'] = $top_final_organization->getLevel();
-	$_SESSION['max_final_authority_level'] = $_SESSION['obj_max_final_authority_level']->organization_level;
+	$_SESSION['max_final_authority_level'] = $_SESSION['obj_max_final_authority_level']->organization_level ?? '';
 }
 if(isset($_SESSION['admin_level']) && ($_SESSION['admin_level'] == 'nation' || $_SESSION['admin_level'] == 'region')) $_SESSION['admin_assistant'] = 0;
 $organizationDAO = $daoFactory->getOrganizationDAO();


### PR DESCRIPTION
## Summary
An account with incomplete organization/storyteller data (no resolvable `users.org_id`, a storyteller row referencing a deleted organization, or a storyteller with no `ww_number`) was tripping three separate warnings on every request to `MoveCharacter.php` and on every page load via `session_setup.inc`:

- `MoveCharacter.php` dereferenced `$userOrganization->globe/nation/region/domain/chapter` without checking `OrganizationDAO::readById()` for `null`, even though `VSSDAO::readLocalVenueVSSs` and `OrganizationDAO::readLocalOrganizations` already treat `null` for each of those params as "no location constraint" — exactly the value a missing organization should produce.
- `session_setup.inc` dereferenced `Organization::getLevel()->organization_level` without checking for `null`, even though `getLevel()` legitimately returns `null` for an organization with no globe/nation/region/domain/chapter set (the `LEFT JOIN` result for an orphaned storyteller `organization_id`), and this file already treats `''` as the "no organization level" default elsewhere.
- `UserInfoDAO::getPositions()` read `$userInfo['super_user']` without checking it exists, even though `getUserInfo()` returns an early fallback array with no `super_user` key for users with no `ww_number`.

All three fixes use `??` to fall back to the value the surrounding code already treats as "nothing here" — no behavior change for accounts with complete data.

## Test plan
- [x] `php -l` on all three edited files — no syntax errors
- [ ] After deploy, load `MoveCharacter.php?char_id=36377` — VSS-selection lists render without a fatal, coming back unconstrained rather than erroring
- [ ] No new occurrences of any of the four original warnings in `/var/log/nginx/legacy_error.log` after deploy