### PR TITLE
fix: parameterize critical SQL injection points (security)

### DIFF
--- a/ModifyCharacterXPListAddXP.php
+++ b/ModifyCharacterXPListAddXP.php
@@ -5,39 +5,33 @@
    if ( $_POST["table"]=="earnedxp" ) {
    	$datestamp = strtotime( stripslashes( $_POST["earneddate"] ) );
 	$mysqldate = strftime( '%Y-%m-%d', $datestamp );
-   	$query=sprintf(
-   		"INSERT INTO earnedxp (".
-   		"  eventname," .
-   		"  earneddate, ".
-   		"  xpearned, ".
-   		"  notes, ".
-   		"  character_id".
-   		") values (".
-   		"  '%s',".
-   		"  '%s',".
-		"  '%s',".
-		"  '%s',".
-		"  %d".
-		")",
-		$db->escape($_POST["eventname"]),
+   	$query = "insert into earnedxp ".
+		"(eventname, earneddate, xpearned, notes, character_id) ".
+		"values (?, ?, ?, ?, ?)";
+	$params = [
+		$_POST["eventname"],
 		$mysqldate,
-		$db->escape($_POST["xpearned"]),
-		$db->escape($_POST["notes"]),
+		$_POST["xpearned"],
+		$_POST["notes"],
 		$_POST["character_id"]
-	);
+	];
   } else {
   	$datestamp = strtotime( stripslashes( $_POST["spentdate"] ) );
-		$mysqldate = strftime( '%Y-%m-%d', $datestamp ); 
-  	$query="insert into spentxp ".
+		$mysqldate = strftime( '%Y-%m-%d', $datestamp );
+  	$query = "insert into spentxp ".
 		"(itembought, spentdate, xpspent, notes, character_id) ".
-		"values ".
-		"('$_POST[itembought]', '$mysqldate', ".
-		"'$_POST[xpspent]', '$_POST[notes]', ".
-		"'$_POST[character_id]')";
+		"values (?, ?, ?, ?, ?)";
+	$params = [
+		$_POST["itembought"],
+		$mysqldate,
+		$_POST["xpspent"],
+		$_POST["notes"],
+		$_POST["character_id"]
+	];
   }
 
-  $db->query($query);
-	
+  $db->query($query, $params);
+
   header("Location: ModifyCharacterXPList1.php?character_id=$_POST[character_id]&");
 ?>
 

--- a/UserDisplay.php
+++ b/UserDisplay.php
@@ -18,14 +18,17 @@ if ( isset( $_GET["return"] ) ) {
 }
 
   if ( isset($_GET["action"]) && $_GET["action"]=="DeleteST" ) {
+    if ( !isset($_SESSION['user_id']) ) {
+      header("Location: index.php");
+      exit;
+    }
     if ( $_GET['venue_id'] == '' ) {
       $_GET['venue_id'] = 0;
     }
-    $query="DELETE from storytellers ".
-           "where user_id='$_GET[id]' and ".
-            "organization_id='$_GET[organization_id]' ".
-           "and venue_id='$_GET[venue_id]'";
-    $db->query($query);
+    $db->query(
+      "DELETE from storytellers where user_id=? and organization_id=? and venue_id=?",
+      [$_GET['id'], $_GET['organization_id'], $_GET['venue_id']]
+    );
     header( "Location: UserDisplay.php?id=$_GET[id]" );
     exit;
   }
@@ -169,7 +172,7 @@ if ( isset( $_GET["return"] ) ) {
     $orgs[] = $row2;
   }
 
-  $db->query("select org_name from organizations where ID='$row[org_id]'");
+  $db->query("select org_name from organizations where ID=?", [$row['org_id']]);
   while( $row2=$db->nextRow() ) {
     $ThisOrgName=$row2["org_name"];
   }
@@ -232,8 +235,8 @@ if ( $mode!="add" ) {
     $query = "SELECT s.id, s.name, v.venue ".
             "FROM vsss s ".
            "LEFT JOIN venues v ON s.venue_id = v.id ".
-           "WHERE storyteller_id = $row[id]";
-    $db->query( $query );
+           "WHERE storyteller_id = ?";
+    $db->query( $query, [$row['id']] );
     while( $vss = $db->nextRow() ) {
       print( "<tr>\n" );
       print( "<td>VSS: <a href='VSSDetails.php?id=$vss[id]&'>$vss[name]</a></td>\n");
@@ -245,7 +248,7 @@ if ( $mode!="add" ) {
                "organizations o on s.organization_id=o.id left join ".
                "venues v on s.venue_id=v.id left join ".
                "users u on s.user_id=u.id ".
-               "where s.user_id=$row[id]");
+               "where s.user_id=?", [$row['id']]);
     while ( $row2=$db->nextRow() ) {
       if ( $row2["globe"]!="" ) {
         print( "<tr>\n" );

--- a/db.inc
+++ b/db.inc
@@ -88,10 +88,10 @@ function userValidForNumber( $id, $camnum ) {
 	if( !is_numeric( $id ) ) {
 		die("INCORRECT USER_ID FOR userValidForNumber FUNCTION - ".$id);
 	}
-	$query="SELECT u.ww_number, u.id ".
-					 "FROM users u	".
-					 "WHERE u.id=$id AND u.ww_number='$camnum'";
-	$res = $db->query("$query" );
+	$res = $db->query(
+		"SELECT u.ww_number, u.id FROM users u WHERE u.id=? AND u.ww_number=?",
+		[$id, $camnum]
+	);
 	if ($res->numRows() > 0) {
 		return true;
 	} else {

--- a/footerbar.inc
+++ b/footerbar.inc
@@ -12,10 +12,10 @@
 <?php
     echo activateUserPopups();
 
-    $query = "SELECT u.username, u.id " .
-             "FROM users u " .
-             "WHERE u.ww_number='" . $_SESSION['cam_number'] . "'";
-    $res = $db->query("$query");
+    $res = $db->query(
+        "SELECT u.username, u.id FROM users u WHERE u.ww_number=?",
+        [$_SESSION['cam_number']]
+    );
     if ($res->numRows() > 1) {
         while ($user_id = $res->nextRow()) {
             print('<div><a href="index.php?SWAP_ID=' . $user_id['id'] . '">Switch to user: ' . $user_id['username'] . '</a></div>');

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,11 @@
   Run "php tools/phpunit.phar" for all suites (see tests/README.md).
 
   Unit tests inject stub doubles for DAOs, so they need no database or settings.inc.
+
+  Integration tests (tests/Integration) run a real top-level page/include in an
+  isolated child PHP process via PageHarness, against an in-memory stub Database
+  (see tests/Integration/stub_includes); still fully offline, no real database.
+  See tests/README.md.
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
@@ -18,6 +23,9 @@
     <testsuites>
         <testsuite name="unit">
             <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/Integration/DbIncSqliTest.php
+++ b/tests/Integration/DbIncSqliTest.php
@@ -1,0 +1,31 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test confirming db.inc's userValidForNumber() binds $camnum as
+ * a query parameter rather than splicing it into the SQL string.
+ * userValidForNumber() has no caller anywhere in the app today, so this runs
+ * it via a small test-only fixture (tests/Integration/fixtures/call_userValidForNumber.php)
+ * that includes the real db.inc and calls the real function.
+ *
+ * @see userValidForNumber() in db.inc
+ */
+final class DbIncSqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "x' OR '1'='1";
+
+	public function testUserValidForNumberBindsCamNumber(): void {
+		$result = PageHarness::run(
+			'tests/Integration/fixtures/call_userValidForNumber.php',
+			get: [ 'id' => '7', 'camnum' => self::TAINTED ],
+			responses: [ [] ]
+		);
+
+		$this->assertCount( 1, $result->queries );
+		$sql = $result->queries[0]['sql'];
+		$this->assertStringNotContainsString( self::TAINTED, $sql );
+		$this->assertStringContainsString( 'u.id=?', $sql );
+		$this->assertStringContainsString( "u.ww_number=?", $sql );
+		$this->assertSame( [ '7', self::TAINTED ], $result->queries[0]['params'] );
+	}
+}

--- a/tests/Integration/FooterbarSqliTest.php
+++ b/tests/Integration/FooterbarSqliTest.php
@@ -1,0 +1,30 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test confirming footerbar.inc's "switch user" lookup binds
+ * $_SESSION['cam_number'] as a query parameter rather than splicing it
+ * directly into the SQL string. footerbar.inc is included at the bottom of
+ * nearly every authenticated page, so this ran on almost every page view
+ * before the fix.
+ *
+ * @see footerbar.inc
+ */
+final class FooterbarSqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "O'Brien123";
+
+	public function testCamNumberLookupIsParameterized(): void {
+		$result = PageHarness::run(
+			'footerbar.inc',
+			session: [ 'cam_number' => self::TAINTED ],
+			responses: [ [] ]
+		);
+
+		$this->assertCount( 1, $result->queries );
+		$sql = $result->queries[0]['sql'];
+		$this->assertStringNotContainsString( self::TAINTED, $sql, 'the tainted value must not be spliced into the SQL text' );
+		$this->assertStringContainsString( 'ww_number=?', $sql );
+		$this->assertSame( [ self::TAINTED ], $result->queries[0]['params'] );
+	}
+}

--- a/tests/Integration/ModifyCharacterXPListAddXPSqliTest.php
+++ b/tests/Integration/ModifyCharacterXPListAddXPSqliTest.php
@@ -1,0 +1,64 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test confirming both branches of ModifyCharacterXPListAddXP.php
+ * bind their POST fields as query parameters. The spent-XP branch previously
+ * interpolated $_POST[itembought/xpspent/notes/character_id] into the SQL
+ * string with no escaping at all -- confirmed causing production fatals on
+ * any apostrophe in itembought/notes (e.g. a note containing "Doesn't Fit
+ * the Character..."). The earned-XP branch avoided crashing via
+ * sprintf()+$db->escape() but is now converted to match.
+ *
+ * @see ModifyCharacterXPListAddXP.php
+ */
+final class ModifyCharacterXPListAddXPSqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "Doesn't Fit the Character";
+
+	public function testSpentXpInsertBindsAllFields(): void {
+		$result = PageHarness::run(
+			'ModifyCharacterXPListAddXP.php',
+			post: [
+				'table'        => 'spentxp',
+				'spentdate'    => '2026-09-05',
+				'itembought'   => self::TAINTED,
+				'xpspent'      => '2',
+				'notes'        => self::TAINTED,
+				'character_id' => '36379',
+			]
+		);
+
+		$this->assertCount( 1, $result->queries );
+		$sql = $result->queries[0]['sql'];
+		$this->assertStringNotContainsString( self::TAINTED, $sql );
+		$this->assertStringStartsWith( 'insert into spentxp', $sql );
+		$this->assertSame(
+			[ self::TAINTED, '2026-09-05', '2', self::TAINTED, '36379' ],
+			$result->queries[0]['params']
+		);
+	}
+
+	public function testEarnedXpInsertBindsAllFields(): void {
+		$result = PageHarness::run(
+			'ModifyCharacterXPListAddXP.php',
+			post: [
+				'table'        => 'earnedxp',
+				'earneddate'   => '2026-09-05',
+				'eventname'    => self::TAINTED,
+				'xpearned'     => '3',
+				'notes'        => self::TAINTED,
+				'character_id' => '36379',
+			]
+		);
+
+		$this->assertCount( 1, $result->queries );
+		$sql = $result->queries[0]['sql'];
+		$this->assertStringNotContainsString( self::TAINTED, $sql );
+		$this->assertStringStartsWith( 'insert into earnedxp', $sql );
+		$this->assertSame(
+			[ self::TAINTED, '2026-09-05', '3', self::TAINTED, '36379' ],
+			$result->queries[0]['params']
+		);
+	}
+}

--- a/tests/Integration/PageHarness.php
+++ b/tests/Integration/PageHarness.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Runs a real top-level application page/include in an isolated child PHP
+ * process against a fully in-memory stub database, and reports back every
+ * SQL statement + bound params the page issued.
+ *
+ * Why a child process rather than an in-process include (as tests/Unit/
+ * does for classes): these are legacy procedural scripts that call
+ * header()/exit()/die() directly and read superglobals at the top level.
+ * Isolating each run in its own process means an exit() call only ends that
+ * child -- it can never take down the PHPUnit run -- while a shutdown
+ * function inside the child still reliably flushes captured queries even
+ * after a fatal error or an explicit exit().
+ *
+ * The real db.inc, header.inc, DAOFactory, and every DAO class run
+ * completely unmodified; only include/Database.class.php and
+ * include/settings.inc are shadowed (via -d include_path, which PHP checks
+ * before a bare include's calling-script directory) with an in-memory
+ * recorder. See stub_includes/include/Database.class.php.
+ *
+ * @see PageHarnessResult
+ */
+class PageHarness {
+
+    /**
+     * @param string $page Path to the target file, relative to the repo root (e.g. "footerbar.inc", "UserDisplay.php").
+     * @param array $get Populates $_GET before the page is included.
+     * @param array $post Populates $_POST before the page is included.
+     * @param array $session Populates $_SESSION before the page is included (after the harness's own session_start(), so it isn't reset).
+     * @param bool $ignoreLogin When true (default), sets a global $IGNORE_LOGIN so header.inc's login gate lets the request through without needing $_SESSION['user_id'] set (which would also trigger the separate, heavier session_setup.inc bootstrap). Set false only when specifically testing login-gate behavior.
+     * @param array $responses Canned row sets returned by successive $db->query() calls, in call order (FIFO) -- each entry is a list of associative-array rows for one query; a query beyond the queued responses gets an empty result.
+     * @return PageHarnessResult The captured queries, any header() calls, and the page's raw output/exit code.
+     * @throws RuntimeException if the child process cannot be started at all (a non-zero exit from the page itself is NOT an error -- that's normal for pages that redirect/die).
+     */
+    public static function run(
+        string $page,
+        array $get = [],
+        array $post = [],
+        array $session = [],
+        bool $ignoreLogin = true,
+        array $responses = []
+    ): PageHarnessResult {
+        $repoRoot = dirname( __DIR__, 2 );
+        $specFile = tempnam( sys_get_temp_dir(), 'aph_spec_' );
+        $outFile  = tempnam( sys_get_temp_dir(), 'aph_out_' );
+
+        file_put_contents( $specFile, json_encode( [
+            'page'        => $page,
+            'get'         => $get,
+            'post'        => $post,
+            'session'     => $session,
+            'ignoreLogin' => $ignoreLogin,
+            'responses'   => $responses,
+            'outFile'     => $outFile,
+        ] ) );
+
+        $driver = __DIR__ . DIRECTORY_SEPARATOR . 'driver.php';
+        $stubPath = __DIR__ . DIRECTORY_SEPARATOR . 'stub_includes';
+
+        $cmd = escapeshellarg( PHP_BINARY )
+            . ' -d include_path=' . escapeshellarg( $stubPath )
+            . ' -d error_reporting=' . escapeshellarg( (string)( E_ALL & ~E_DEPRECATED ) )
+            . ' -d display_errors=1'
+            . ' -d session.save_path=' . escapeshellarg( sys_get_temp_dir() )
+            . ' ' . escapeshellarg( $driver )
+            . ' ' . escapeshellarg( $specFile );
+
+        $descriptors = [ 1 => [ 'pipe', 'w' ], 2 => [ 'pipe', 'w' ] ];
+        $process = proc_open( $cmd, $descriptors, $pipes, $repoRoot );
+        if ( !is_resource( $process ) ) {
+            @unlink( $specFile );
+            @unlink( $outFile );
+            throw new RuntimeException( "PageHarness: failed to start child process for $page" );
+        }
+
+        $stdout = stream_get_contents( $pipes[1] );
+        $stderr = stream_get_contents( $pipes[2] );
+        fclose( $pipes[1] );
+        fclose( $pipes[2] );
+        $exitCode = proc_close( $process );
+
+        $captured = [];
+        if ( is_file( $outFile ) ) {
+            $captured = json_decode( file_get_contents( $outFile ), true ) ?? [];
+            @unlink( $outFile );
+        }
+        @unlink( $specFile );
+
+        return new PageHarnessResult(
+            $captured['queries'] ?? [],
+            $captured['headers'] ?? [],
+            $stdout,
+            $stderr,
+            $exitCode
+        );
+    }
+}
+
+/** Result of one PageHarness::run() call. */
+class PageHarnessResult {
+    /** @param array $queries Each entry: ['sql' => string, 'params' => array, 'db' => string]. */
+    public function __construct(
+        public readonly array $queries,
+        public readonly array $headers,
+        public readonly string $output,
+        public readonly string $stderr,
+        public readonly int $exitCode
+    ) {}
+
+    /** The SQL text of every captured query, in call order. */
+    public function sqlStatements(): array {
+        return array_column( $this->queries, 'sql' );
+    }
+
+    /** True if any captured query's SQL text contains $needle verbatim (e.g. to assert a raw value was NOT interpolated). */
+    public function anyQueryContains( string $needle ): bool {
+        foreach ( $this->sqlStatements() as $sql ) {
+            if ( str_contains( $sql, $needle ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** True if any captured query's params array contains $needle as one of its bound values. */
+    public function anyParamsContain( mixed $needle ): bool {
+        foreach ( $this->queries as $q ) {
+            if ( in_array( $needle, $q['params'], true ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/tests/Integration/UserDisplaySqliTest.php
+++ b/tests/Integration/UserDisplaySqliTest.php
@@ -1,0 +1,51 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression tests for UserDisplay.php's "DeleteST" action: it used to have
+ * no login check at all (header.inc, this file's login gate, isn't included
+ * until well after this block runs) AND built its DELETE by interpolating
+ * three raw $_GET values with no escaping -- an unauthenticated, injectable,
+ * destructive DELETE. The fix adds a login check ahead of the query and
+ * parameterizes it.
+ *
+ * @see UserDisplay.php
+ */
+final class UserDisplaySqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "1' OR '1'='1";
+
+	/** With no session at all, the delete must not run -- zero queries issued. */
+	public function testDeleteStWithNoSessionRunsNoQuery(): void {
+		$result = PageHarness::run(
+			'UserDisplay.php',
+			get: [ 'action' => 'DeleteST', 'id' => self::TAINTED, 'organization_id' => '2', 'venue_id' => '3' ],
+			session: []
+		);
+
+		$this->assertSame( [], $result->queries, 'an unauthenticated request must not reach the DELETE at all' );
+	}
+
+	/** With a session present, the delete runs, parameterized, with the tainted value only in params. */
+	public function testDeleteStWithSessionBindsAllThreeValues(): void {
+		$result = PageHarness::run(
+			'UserDisplay.php',
+			get: [ 'action' => 'DeleteST', 'id' => self::TAINTED, 'organization_id' => '2', 'venue_id' => '3' ],
+			// Setting $_SESSION['user_id'] also pulls in db.inc's own
+			// session_setup.inc bootstrap as a side effect, which issues a
+			// few queries of its own first -- find the DELETE specifically
+			// rather than assuming it's the first query captured.
+			session: [ 'user_id' => '42' ]
+		);
+
+		$deletes = array_values( array_filter(
+			$result->queries,
+			fn( $q ) => str_starts_with( $q['sql'], 'DELETE from storytellers' )
+		) );
+
+		$this->assertCount( 1, $deletes, 'expected exactly one DELETE from storytellers query' );
+		$this->assertStringNotContainsString( self::TAINTED, $deletes[0]['sql'] );
+		$this->assertSame( 'DELETE from storytellers where user_id=? and organization_id=? and venue_id=?', $deletes[0]['sql'] );
+		$this->assertSame( [ self::TAINTED, '2', '3' ], $deletes[0]['params'] );
+	}
+}

--- a/tests/Integration/driver.php
+++ b/tests/Integration/driver.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Standalone child-process driver for PageHarness::run().
+ *
+ * Reads a JSON spec (argv[1]) describing $_GET/$_POST/$_SESSION and canned
+ * DB row responses, then includes the target application page under those
+ * conditions with include_path shadowing the real Database class (see
+ * stub_includes/include/Database.class.php) -- every other included file
+ * (db.inc, header.inc, DAOFactory, every DAO class) is the real, unmodified
+ * application code. Captures every query issued to the stub $db and, via a
+ * shutdown function (so it still fires if the page calls exit()/die() or
+ * hits a fatal error), writes them to the spec's outFile as JSON.
+ *
+ * Never run directly -- always invoked by PageHarness::run() as a php -d
+ * include_path=... child process with cwd set to the repo root.
+ */
+
+$specFile = $argv[1] ?? null;
+if ( !$specFile || !is_file( $specFile ) ) {
+    fwrite( STDERR, "driver.php: missing or unreadable spec file\n" );
+    exit( 2 );
+}
+$spec = json_decode( file_get_contents( $specFile ), true );
+if ( !is_array( $spec ) ) {
+    fwrite( STDERR, "driver.php: spec file did not contain valid JSON\n" );
+    exit( 2 );
+}
+
+$GLOBALS['__captured_queries'] = [];
+$GLOBALS['__stub_responses'] = $spec['responses'] ?? [];
+
+register_shutdown_function( function () use ( $spec ) {
+    $out = [
+        'queries' => $GLOBALS['__captured_queries'] ?? [],
+        'headers' => function_exists( 'headers_list' ) ? headers_list() : [],
+    ];
+    file_put_contents( $spec['outFile'], json_encode( $out ) );
+} );
+
+$_GET = $spec['get'] ?? [];
+$_POST = $spec['post'] ?? [];
+
+// Start the session ourselves first so real db.inc's own
+// `if (session_status() === PHP_SESSION_NONE) { session_start(); }` guard
+// sees an already-active session and skips re-starting it -- otherwise
+// CLI's session_start() would reset $_SESSION back to empty.
+session_start();
+$_SESSION = $spec['session'] ?? [];
+
+if ( !empty( $spec['ignoreLogin'] ) ) {
+    // header.inc's login gate is `!isset($_SESSION['user_id']) && !isset($IGNORE_LOGIN)`;
+    // setting this lets tests exercise pages that sit behind that gate without
+    // needing $_SESSION['user_id'] set (which would also pull in the much
+    // heavier session_setup.inc bootstrap via db.inc).
+    $GLOBALS['IGNORE_LOGIN'] = 1;
+}
+
+include getcwd() . '/' . $spec['page'];

--- a/tests/Integration/fixtures/call_userValidForNumber.php
+++ b/tests/Integration/fixtures/call_userValidForNumber.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Test-only entry point for tests/Integration/DbIncSqliTest.php.
+ *
+ * userValidForNumber() (defined in db.inc) has no real caller anywhere in the
+ * app today, so there is no existing page to point PageHarness at -- this
+ * fixture just includes db.inc (which defines the function as a side effect
+ * of loading) and calls it with the request's id/camnum, echoing the result.
+ * It exercises the real function body, unmodified.
+ */
+include_once( "db.inc" );
+
+echo userValidForNumber( $_GET['id'], $_GET['camnum'] ) ? '1' : '0';

--- a/tests/Integration/stub_includes/include/Database.class.php
+++ b/tests/Integration/stub_includes/include/Database.class.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Stub replacement for include/Database.class.php, used ONLY by the
+ * Integration test harness (tests/Integration/PageHarness.php) via PHP's
+ * include_path resolution: a bare `include_once("include/Database.class.php")`
+ * checks include_path before the calling script's own directory, so pointing
+ * php's -d include_path at this file's parent directory makes every real
+ * application file (db.inc, DAOFactory, every DAO class) transparently talk
+ * to this in-memory recorder instead of a real MySQL connection.
+ *
+ * Every query passed to Database::query() is appended to a global capture
+ * list (read back by the harness after the driver process exits) instead of
+ * being executed, and returns a canned row set popped from a global queue the
+ * driver script populates from the test's fixture file. No network I/O, no
+ * real settings.inc, no real mysqli extension calls.
+ */
+
+class Database {
+    public $db_host;
+    public $db_user;
+    public $db_pass;
+    public $db_name;
+    public $dbh;
+    public $lastResult;
+
+    public function __construct( $host = null, $user = null, $pass = null, $name = null ) {
+        $this->db_host = $host;
+        $this->db_user = $user;
+        $this->db_pass = $pass;
+        $this->db_name = $name;
+        $this->dbh = null;
+    }
+
+    /** Mirrors the real class's escape() shape; no real mysqli handle exists, so this is a plain fallback. */
+    function escape( $source ) {
+        return addslashes( (string)$source );
+    }
+
+    /**
+     * Records the query instead of running it, and returns the next canned
+     * row set queued for this connection (FIFO), defaulting to an empty
+     * result when the test didn't queue one for this call.
+     */
+    function query( string $query, array $params = [] ) {
+        $GLOBALS['__captured_queries'][] = [ 'sql' => $query, 'params' => $params, 'db' => $this->db_name ];
+        $rows = array_shift( $GLOBALS['__stub_responses'] ) ?? [];
+        $this->lastResult = new StubResultSet( $rows );
+        return $this->lastResult;
+    }
+
+    function throwError() {
+        // Real class echoes debug info then exit()s on a query failure.
+        // The stub never fails a query, so this should never be reached.
+        exit( 1 );
+    }
+
+    function getAllRows() { return $this->lastResult->getAllRows(); }
+    function getFieldCount() { return $this->lastResult->getFieldCount(); }
+    function getFieldNames() { return $this->lastResult->getFieldNames(); }
+    function nextRow() { return $this->lastResult->nextRow(); }
+    function numRows() { return $this->lastResult->numRows(); }
+    function affectedRows() { return $this->lastResult->affectedRows(); }
+    function getField( $field ) { return $this->lastResult->getField( $field ); }
+    function getInsertId() { return 1; }
+}
+
+/** Mirrors include/ResultSet.class.php's public interface over a plain PHP array of assoc rows -- no mysqli_result involved. */
+class StubResultSet {
+    private $rows;
+    private $currentRow = 0;
+
+    public function __construct( array $rows ) {
+        $this->rows = array_values( $rows );
+    }
+
+    function getFieldCount() { return count( $this->rows ) > 0 ? count( $this->rows[0] ) : 0; }
+    function getFieldNames() { return count( $this->rows ) > 0 ? array_keys( $this->rows[0] ) : []; }
+
+    function nextRow() {
+        if ( isset( $this->rows[$this->currentRow] ) ) {
+            return $this->rows[$this->currentRow++];
+        }
+        return array();
+    }
+
+    function numRows() { return count( $this->rows ); }
+    function affectedRows() { return 0; }
+    function getField( $field ) { return $this->rows[$this->currentRow][$field] ?? null; }
+    function getAllRows() { return $this->rows; }
+}

--- a/tests/Integration/stub_includes/include/settings.inc
+++ b/tests/Integration/stub_includes/include/settings.inc
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Stub replacement for include/settings.inc, used only by the Integration
+ * test harness via include_path shadowing (see stub_includes/include/Database.class.php
+ * for the mechanism). Values are dummy placeholders -- the stub Database
+ * class never actually connects to them.
+ */
+
+$SETTINGS = array();
+
+$SETTINGS["APPROVALS_SERVER"]   = "stub";
+$SETTINGS["APPROVALS_USERNAME"] = "stub";
+$SETTINGS["APPROVALS_PASSWORD"] = "stub";
+$SETTINGS["APPROVALS_DATABASE"] = "approvals_2017";
+
+$SETTINGS["PORTAL_SERVER"]      = "stub";
+$SETTINGS["PORTAL_USERNAME"]    = "stub";
+$SETTINGS["PORTAL_PASSWORD"]    = "stub";
+$SETTINGS["PORTAL_DATABASE"]    = "mes-portal";
+
+$SETTINGS["OAUTH_CLIENT_ID"]     = "stub";
+$SETTINGS["OAUTH_CLIENT_SECRET"] = "stub";
+$SETTINGS["OAUTH_REDIRECT_URI"]  = "https://example.test/oauth_callback.php";
+$SETTINGS["OAUTH_TOKEN_URL"]     = "https://example.test/oauth/v2/token";
+$SETTINGS["OAUTH_API_URL"]       = "https://example.test/api/authorized/user.json";
+
+$SETTINGS["EARLY_ACCESS_ENABLED"] = false;
+$SETTINGS["GOOGLE_MAP_SYNC_ENABLED"] = false;

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,21 +17,58 @@ tools\get-phpunit.ps1       # Windows PowerShell
 ## Running
 
 ```bash
-php tools/phpunit.phar                    # all suites (config: phpunit.xml)
-php tools/phpunit.phar --testsuite unit   # unit suite only
+php tools/phpunit.phar                          # all suites (config: phpunit.xml)
+php tools/phpunit.phar --testsuite unit         # unit suite only
+php tools/phpunit.phar --testsuite integration  # integration suite only
 ```
 
 ## Layout
 
 - `tests/Unit/` — fast, offline unit tests. They inject **stub doubles** for DAOs, so
   they need no database and never load `include/settings.inc`. See `tests/bootstrap.php`.
+  `tests/Unit/support/` holds shared test doubles (not test files themselves) — e.g.
+  `RecordingDb.php`, a stand-in `Database` that records every `query($sql, $params)`
+  call, used by the SQL-injection regression tests to assert a query uses `?`
+  placeholders and that a tainted value only ever appears in `$params`.
+- `tests/Integration/` — runs a real top-level page/include (not just a class) in an
+  **isolated child PHP process** via `PageHarness::run()`, against an in-memory stub
+  `Database` (`tests/Integration/stub_includes/`) — still fully offline, no real
+  database. This exists because many of this app's page scripts are top-level
+  procedural code that calls `header()`/`exit()` directly and reads `$_GET`/`$_POST`/
+  `$_SESSION` — not unit-testable in-process the way a class is. Process isolation
+  means an `exit()` inside the target page only ends that child process; a shutdown
+  function in the child still flushes captured queries even after a fatal error.
+  The mechanism: only `include/Database.class.php` and `include/settings.inc` are
+  shadowed via PHP's `include_path` (checked before a bare include's calling-script
+  directory) — the real `db.inc`, `header.inc`, `DAOFactory`, and every DAO class run
+  completely unmodified against the stub connection.
+  **Known gap:** any page that transitively includes `application.inc` (which
+  `require_once`s Smarty from a hardcoded absolute Linux path,
+  `/usr/share/php/smarty3/SmartyBC.class.php`) cannot run under this harness on a
+  machine without that exact path — absolute-path includes bypass `include_path`
+  shadowing entirely. Those pages currently rely on the manual QA steps in their
+  PR's test plan instead.
 - `tests/test_final_approval.php` — a pre-existing self-contained **live-DB integration**
   script (its own assert harness). Run directly: `php tests/test_final_approval.php`.
-  It is not part of the `unit` suite because it requires DB connectivity and fixtures.
+  It is not part of either suite because it requires DB connectivity and fixtures.
 
 ## Writing a unit test
 
 `require_once` the app file under test at the top (the bootstrap has already `chdir`'d to
 the repo root), then inject anonymous-class stubs for its collaborators. Example pattern:
 `tests/Unit/GetLowSTTest.php` constructs `ApplicationService` with four stub DAOs and asserts
-the resolved storyteller id for each `vss_id` branch.
+the resolved storyteller id for each `vss_id` branch. For a query-building test, use
+`tests/Unit/support/RecordingDb.php` instead of an ad hoc stub — see
+`tests/Unit/UserInfoDAOSqliTest.php` for the pattern.
+
+## Writing an integration (page-script) test
+
+`require_once 'tests/Integration/PageHarness.php'`, then call
+`PageHarness::run($page, get: [...], post: [...], session: [...], responses: [...])`
+and assert on the returned `PageHarnessResult` (`->queries`, `->sqlStatements()`,
+`->anyQueryContains()`, `->anyParamsContain()`, `->exitCode`). `ignoreLogin` defaults to
+`true`, bypassing `header.inc`'s login gate without needing `$_SESSION['user_id']` set
+(which would also trigger the heavier `session_setup.inc` bootstrap) — pass `false` only
+when specifically testing login-gate behavior. `responses` supplies one row-array per
+expected `$db->query()` call, in call order; a call beyond the queued responses gets an
+empty result. See `tests/Integration/FooterbarSqliTest.php` for the pattern.

--- a/tests/Unit/support/RecordingDb.php
+++ b/tests/Unit/support/RecordingDb.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Minimal stand-in for the real Database class, shared by the SQL-injection
+ * regression tests: records every SQL string and bound params array passed
+ * to query(), and returns a canned row set (or none) so a test can assert
+ * the query text uses ?-placeholders and that a tainted value only ever
+ * appears in $params, never spliced into $sql.
+ *
+ * @see Database in include/Database.class.php, the real class this doubles for.
+ */
+class RecordingDb {
+	/** @var array<int, array{sql: string, params: array}> Every query() call, in order. */
+	public array $queries = [];
+
+	private array $responses;
+	private array $lastRows = [];
+	private int $cursor = 0;
+
+	/** @param array $responses One row-array per expected query() call, in call order (FIFO). A call beyond the queued responses gets no rows. */
+	public function __construct( array $responses = [] ) {
+		$this->responses = $responses;
+	}
+
+	public function query( string $sql, array $params = [] ) {
+		$this->queries[] = [ 'sql' => $sql, 'params' => $params ];
+		$this->lastRows = array_shift( $this->responses ) ?? [];
+		$this->cursor = 0;
+		return $this;
+	}
+
+	public function escape( $value ) {
+		return addslashes( (string)$value );
+	}
+
+	public function nextRow() {
+		if ( isset( $this->lastRows[ $this->cursor ] ) ) {
+			return $this->lastRows[ $this->cursor++ ];
+		}
+		return array();
+	}
+
+	public function numRows(): int {
+		return count( $this->lastRows );
+	}
+
+	public function getAllRows(): array {
+		return $this->lastRows;
+	}
+
+	/** The SQL text of every query() call, in order. */
+	public function sqlStatements(): array {
+		return array_column( $this->queries, 'sql' );
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #30, #31, #32, #33 — the highest-severity findings from the 2026-09-05 repo-wide SQL injection audit.

- **`footerbar.inc`** (#30): raw `$_SESSION['cam_number']` interpolation in a lookup that runs on nearly every authenticated page.
- **`db.inc`** (#31): `userValidForNumber()` raw-interpolates `$camnum` — currently dead code, but sits in the most-included file in the app.
- **`UserDisplay.php`** (#32): three query sites with raw `$_GET`/`$_POST`/`$row[...]` interpolation, the worst being the `DeleteST` action — a destructive DELETE reachable **with no login check at all** (`header.inc` isn't included until after it runs). Adds a login check there alongside the SQL fix.
- **`ModifyCharacterXPListAddXP.php`** (#33): the spent-XP insert branch had zero escaping and was already confirmed causing production fatals on any apostrophe in `itembought`/`notes`; the earned-XP branch used the safer-but-older `sprintf()`+`$db->escape()` pattern and is now converted to match.

All five fixes use the `?`/`$params` support `include/Database.class.php` already provides via `mysqli_execute_query()`, matching the pattern already established in `ModifyCharacterXPList4.php`.

This is PR 1 of 3 in the remediation plan — PR 2 (remaining page-script injection points) and PR 3 (DAO/service-layer hardening, lower urgency) follow separately.

## Test plan
- [x] `php -l` on all four files — no syntax errors
- [ ] After deploy, submit a spent-XP entry with an apostrophe (e.g. `itembought = "Wizard's Staff"`) — saves correctly, no fatal
- [ ] Confirm `UserDisplay.php?action=DeleteST&...` without a session now redirects to login instead of executing
- [ ] Spot-check `footerbar.inc`'s "Switch to user" popup still works for an account with multiple linked users
- [ ] Tail `/var/log/nginx/legacy_error.log` after deploy for any new SQL-related fatals