### PR TITLE
fix: parameterize remaining page-script SQL injection points (security)

### DIFF
--- a/DisplayCharacter.php
+++ b/DisplayCharacter.php
@@ -11,9 +11,10 @@
 				 "vsss s on c.vss_id = s.id left join ".
 				 "organizations o on c.vss_id = -o.id left join ".
 				 "users u on c.user_id=u.id ".
-		     "where c.id='$thischar_id' AND ".
+		     "where c.id=? AND ".
 				 "(".
-				 "u.id='$_SESSION[user_id]' ";
+				 "u.id=? ";
+  $params = [ $thischar_id, $_SESSION['user_id'] ];
   if( sizeof($_SESSION["admin_vss_list"]) > 0 ) {
     $query.="OR c.vss_id in ('" . implode("','",$_SESSION["admin_vss_list"]) . "') ";
 	}
@@ -26,7 +27,7 @@
   $query.=")";
 
 	$query.=" order by name";
-	$db->query($query);
+	$db->query($query, $params);
 	$character = $db->nextRow();
 	foreach($character as $key => $val){
 		$character[$key] = strip_tags($val);
@@ -36,7 +37,10 @@
 		 echo("<div class=\"subhead\" align=\"center\">You do not have access to view this character</div>");
 	} else {
 	  if( $_SESSION['user_id'] != $character['user_id'] ) {
-		  $db->query("INSERT INTO activity_log ( activity_date, character_id, user_id, description ) values ( now(), $thischar_id, $_SESSION[user_id], 'Viewed Character Sheet and Background' )");
+		  $db->query(
+			  "INSERT INTO activity_log ( activity_date, character_id, user_id, description ) values ( now(), ?, ?, 'Viewed Character Sheet and Background' )",
+			  [ $thischar_id, $_SESSION['user_id'] ]
+		  );
 		}
 
 		$isStoryteller = !empty($_SESSION['admin_vss_list']) || !empty($_SESSION['admin_org_list']);

--- a/EventsDetails.php
+++ b/EventsDetails.php
@@ -10,7 +10,7 @@
                "FROM events e ".
 							 "LEFT JOIN vsss v on e.vss_id=v.id ".
 							 "LEFT JOIN organizations o on -e.vss_id=o.id ".
-               "WHERE e.id=$id");
+               "WHERE e.id=?", [$id]);
     $detailrow=$db->nextRow();
   } else {
     $detailrow=array();

--- a/MechanicsDetails.php
+++ b/MechanicsDetails.php
@@ -58,9 +58,9 @@ active, a yes/no (bit)
   $query="SELECT m.*, v.venue ".
 					"FROM mechanics m left join ".
 					"venues v on m.venue_id=v.id ".
-					"WHERE m.id='$_GET[id]' ".
+					"WHERE m.id=? ".
 					"ORDER BY v.id, m.category , m.title";
-  $result = $db->query($query);
+  $result = $db->query($query, [$_GET['id']]);
   $row=$result->nextRow();
 ?>
 

--- a/ModifyCharacterList3.php
+++ b/ModifyCharacterList3.php
@@ -4,7 +4,7 @@
 	$db->query("select c.*, v.venue, u.org_id from characters c ".
 	  "left join venues v on c.venue_id = v.id " .
 	  "left join users u on c.user_id = u.id " .
-		"where c.ID='$thisModify' order by name");
+		"where c.ID=? order by name", [$thisModify]);
 	$character = $db->nextRow();
 	$thisVenue=$character["venue_id"];
 

--- a/ModifyCharacterXPList1.php
+++ b/ModifyCharacterXPList1.php
@@ -24,8 +24,10 @@ notes - text/varchar
 */
   include_once("db.inc");
 
-	$earnedsort= ( isset($_GET["earnedsort"]) ? $_GET["earnedsort"] : "earneddate");
-	$spentsort= ( isset($_GET["spentsort"]) ? $_GET["spentsort"] : "spentdate");
+	$earnedsort = in_array($_GET["earnedsort"] ?? '', ['eventname','earneddate','xpearned','notes'], true)
+		? $_GET["earnedsort"] : "earneddate";
+	$spentsort = in_array($_GET["spentsort"] ?? '', ['itembought','spentdate','xpspent','notes'], true)
+		? $_GET["spentsort"] : "spentdate";
 	$earnedinverted= ( isset($_GET["earnedinverted"]) ? 1 : 0);
 	$spentinverted= ( isset($_GET["spentinverted"]) ? 1 : 0);
 	// CSS class applied to the active sort-column header (never assigned a value

--- a/ModifyCharacterXPList2.php
+++ b/ModifyCharacterXPList2.php
@@ -9,8 +9,11 @@
 		$thistable="spentxp";
 	}
 	if ( !empty( $_POST["delete"] ) && empty( $_POST["modify"] )) {
-		$thisDelete = "('" . implode( "','", $_POST["delete"] ) . "')";
-		$db->query("DELETE FROM $thistable WHERE id IN $thisDelete and id!='$modify'");
+		$placeholders = implode(",", array_fill(0, count($_POST["delete"]), "?"));
+		$db->query(
+			"DELETE FROM $thistable WHERE id IN ($placeholders) and id!=?",
+			array_merge($_POST["delete"], [$modify])
+		);
 	  header("Location: ModifyCharacterXPList1.php?character_id=$_POST[character_id]&");
 		exit();
 	} else if( !empty( $_POST['modify']) && is_numeric($_POST['modify']) ) {

--- a/ModifyCharacterXPList3.php
+++ b/ModifyCharacterXPList3.php
@@ -4,10 +4,10 @@
 	include_once("header.inc");
 	include_once("titlebar.php");
 	$thisModify = $_GET['modify'];
-	$thisTable=$_GET["table"];
+	$thisTable = ($_GET["table"] === "earnedxp") ? "earnedxp" : "spentxp";
 	$thisDate = ( $thisTable == "earnedxp" ) ? "earneddate" : "spentdate";
-	
-	$db->query("select * from $thisTable where id=$thisModify");
+
+	$db->query("select * from $thisTable where id=?", [$thisModify]);
 	$row = $db->nextRow();
 ?>
 

--- a/ModifyNPCList3.php
+++ b/ModifyNPCList3.php
@@ -4,7 +4,7 @@
 	$db->query("select c.*, v.venue, u.org_id from characters c ".
 	  "left join venues v on c.venue_id = v.id " .
 	  "left join users u on c.user_id = u.id " .
-		"where c.ID='$thisModify' order by name");
+		"where c.ID=? order by name", [$thisModify]);
 	$character = $db->nextRow();
 	$thisVenue=$character["venue_id"];
   if ( $character["user_id"]!=$_SESSION['user_id'] &&

--- a/ModifyOrgList3.php
+++ b/ModifyOrgList3.php
@@ -17,7 +17,7 @@
    }
 
   // Use the org being modified to determine the hierarchy context for the form
-  $db->query("select * from organizations where id='$ThisModify'");
+  $db->query("select * from organizations where id=?", [$ThisModify]);
   $row=$db->nextRow();
   if (!$row) {
     header("Location: ModifyOrgList1.php");
@@ -28,7 +28,7 @@
   $ThisDomain = isset($row["domain"]) ? $row["domain"] : "";
   $ThisChapter = isset($row["chapter"]) ? $row["chapter"] : "";
 
-  $db->query("select * from organizations where id='$ThisModify'");
+  $db->query("select * from organizations where id=?", [$ThisModify]);
 
   $row = $db->nextRow();
   if (!$row) {

--- a/ModifyVenueList2.php
+++ b/ModifyVenueList2.php
@@ -4,8 +4,8 @@
 	$modify = $_POST["modify"];
 	
 	if ( isset( $_POST["delete"] ) ) {
-		$thisDelete = "(" . implode( ",", $_POST["delete"] ) . ")";
-		$db->query("DELETE FROM venues WHERE id IN $thisDelete");
+		$placeholders = implode(",", array_fill(0, count($_POST["delete"]), "?"));
+		$db->query("DELETE FROM venues WHERE id IN ($placeholders)", $_POST["delete"]);
 		$modifyInDelete = in_array( $modify, $_POST["delete"]);
 	} 
 	if( isset($_POST["modify"]) && !$modifyInDelete ) {

--- a/ModifyVenueList3.php
+++ b/ModifyVenueList3.php
@@ -4,7 +4,7 @@
 	include_once("header.inc");
 	include_once("titlebar.php");
   $thisModify = $_GET["modify"];
-	$db->query("select * from venues where ID='$thisModify'");
+	$db->query("select * from venues where ID=?", [$thisModify]);
   $row = $db->nextRow();
  ?>
 

--- a/MoveCharacter2.php
+++ b/MoveCharacter2.php
@@ -24,11 +24,13 @@
   	}
     if( $character['vss_id'] != $vss_id ) {
       if( $vss_id < 0 ) {
-        $query = "SELECT u.* FROM organizations o LEFT JOIN users u ON u.id = o.admin_user_id WHERE o.id=-1*$vss_id";
+        $query = "SELECT u.* FROM organizations o LEFT JOIN users u ON u.id = o.admin_user_id WHERE o.id=?";
+        $params = [ -1 * (int)$vss_id ];
       } else {
-        $query = "SELECT u.* FROM vsss v LEFT JOIN users u ON u.id = v.storyteller_id WHERE v.id=$vss_id";
+        $query = "SELECT u.* FROM vsss v LEFT JOIN users u ON u.id = v.storyteller_id WHERE v.id=?";
+        $params = [ (int)$vss_id ];
       }
-      $db->query( $query );
+      $db->query( $query, $params );
       if( $storyteller = $db->nextRow() )
       {
  	$user_info = $userInfoDAO->getUserInfo($storyteller['id']);

--- a/VSSDetails.php
+++ b/VSSDetails.php
@@ -8,8 +8,8 @@
 				 " left join organizations o on v.org_id=o.id".
 				 " left join venues n on v.venue_id=n.id".
 				 " left join users u on v.storyteller_id=u.id".
-		  	 " WHERE v.id='$_GET[id]' ";
-  $res = $db->query($query);
+		  	 " WHERE v.id=? ";
+  $res = $db->query($query, [$_GET['id']]);
 
  ?>
 <!DOCTYPE html>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,11 @@
   Run "php tools/phpunit.phar" for all suites (see tests/README.md).
 
   Unit tests inject stub doubles for DAOs, so they need no database or settings.inc.
+
+  Integration tests (tests/Integration) run a real top-level page/include in an
+  isolated child PHP process via PageHarness, against an in-memory stub Database
+  (see tests/Integration/stub_includes); still fully offline, no real database.
+  See tests/README.md.
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
@@ -18,6 +23,9 @@
     <testsuites>
         <testsuite name="unit">
             <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/Integration/DisplayCharacterSqliTest.php
+++ b/tests/Integration/DisplayCharacterSqliTest.php
@@ -1,0 +1,69 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test confirming DisplayCharacter.php binds the tainted GET
+ * `char_id` as a `?` parameter in both places it drives a query: the main
+ * character lookup (alongside $_SESSION['user_id']) and the activity-log
+ * INSERT fired when the viewer isn't the character's owner.
+ *
+ * Setting $_SESSION['user_id'] also pulls in db.inc's own session_setup.inc
+ * bootstrap as a side effect, which issues five queries of its own first --
+ * hence the five leading empty placeholders in `responses` before the real
+ * character row, and why the assertions filter `->queries` for the specific
+ * statements rather than assuming a fixed index.
+ *
+ * @see DisplayCharacter.php
+ */
+final class DisplayCharacterSqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "1' OR '1'='1";
+
+	/** Both the character lookup and the activity-log insert bind the tainted char_id only via params. */
+	public function testCharacterLookupAndActivityLogInsertBindTaintedCharId(): void {
+		$characterRow = [
+			'id'               => '555',
+			'name'             => 'Test Character',
+			'venue'            => 'Test Venue',
+			'venue_id'         => '5',
+			'char_type'        => 'PC',
+			'vss_id'           => '0',
+			'vss_name'         => '',
+			'org_name'         => '',
+			'approved_in_vss'  => '0',
+			'subtype'          => 'Vampire',
+			'active'           => '1',
+			'char_dead'        => '0',
+			'character_sheet'  => 'Sheet body text',
+			'background'       => 'Background body text',
+			'user_id'          => '1', // deliberately different from the session's viewer id, so the activity-log insert branch fires
+			'org_id'           => '0',
+		];
+
+		$result = PageHarness::run(
+			'DisplayCharacter.php',
+			get: [ 'char_id' => self::TAINTED ],
+			session: [ 'user_id' => 99, 'admin_vss_list' => [], 'admin_org_list' => [] ],
+			responses: [ [], [], [], [], [], [ $characterRow ] ]
+		);
+
+		$lookups = array_values( array_filter(
+			$result->queries,
+			fn( $q ) => str_starts_with( $q['sql'], 'select c.*,' )
+		) );
+		$inserts = array_values( array_filter(
+			$result->queries,
+			fn( $q ) => str_starts_with( $q['sql'], 'INSERT INTO activity_log' )
+		) );
+
+		$this->assertCount( 1, $lookups, 'expected exactly one character lookup query' );
+		$this->assertStringNotContainsString( self::TAINTED, $lookups[0]['sql'] );
+		$this->assertStringContainsString( 'c.id=?', $lookups[0]['sql'] );
+		$this->assertStringContainsString( 'u.id=?', $lookups[0]['sql'] );
+		$this->assertSame( [ self::TAINTED, 99 ], $lookups[0]['params'] );
+
+		$this->assertCount( 1, $inserts, 'expected the activity-log insert to have fired' );
+		$this->assertStringNotContainsString( self::TAINTED, $inserts[0]['sql'] );
+		$this->assertSame( [ self::TAINTED, 99 ], $inserts[0]['params'] );
+	}
+}

--- a/tests/Integration/EventsDetailsSqliTest.php
+++ b/tests/Integration/EventsDetailsSqliTest.php
@@ -1,0 +1,36 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test confirming EventsDetails.php's event lookup binds the GET
+ * "id" value as a query parameter rather than splicing it directly into the
+ * SQL string. The lookup only runs when "id" is non-empty, so the SQLi
+ * payload used here (which is non-empty) doubles as the exercised value.
+ *
+ * @see EventsDetails.php
+ */
+final class EventsDetailsSqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "1' OR '1'='1";
+
+	/** The event lookup uses a "?" placeholder and binds the tainted value only as a parameter, among other unrelated queries the page issues afterward. */
+	public function testEventLookupIsParameterized(): void {
+		$result = PageHarness::run(
+			'EventsDetails.php',
+			get: [ 'id' => self::TAINTED ],
+			// header.inc's generateMenus() calls count() on these two session
+			// keys unconditionally; leaving them unset is a fatal TypeError
+			// under PHP 8, and header.inc runs before the event query.
+			session: [ 'admin_org_list' => [], 'admin_vss_list' => [] ]
+		);
+
+		$eventQueries = array_values( array_filter(
+			$result->queries,
+			fn( $q ) => str_contains( $q['sql'], 'e.id=?' )
+		) );
+
+		$this->assertCount( 1, $eventQueries, 'expected exactly one event lookup query' );
+		$this->assertStringNotContainsString( self::TAINTED, $eventQueries[0]['sql'], 'the tainted value must not be spliced into the SQL text' );
+		$this->assertContains( self::TAINTED, $eventQueries[0]['params'] );
+	}
+}

--- a/tests/Integration/MechanicsDetailsSqliTest.php
+++ b/tests/Integration/MechanicsDetailsSqliTest.php
@@ -1,0 +1,35 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test confirming MechanicsDetails.php's mechanic lookup binds
+ * the GET "id" value as a query parameter rather than splicing it directly
+ * into the SQL string.
+ *
+ * @see MechanicsDetails.php
+ */
+final class MechanicsDetailsSqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "1' OR '1'='1";
+
+	/** The mechanic lookup uses a "?" placeholder and binds the tainted value only as a parameter, among other unrelated queries the page issues first. */
+	public function testMechanicLookupIsParameterized(): void {
+		$result = PageHarness::run(
+			'MechanicsDetails.php',
+			get: [ 'id' => self::TAINTED ],
+			// header.inc's generateMenus() calls count() on these two session
+			// keys unconditionally; leaving them unset is a fatal TypeError
+			// under PHP 8, and header.inc runs before the mechanic query.
+			session: [ 'admin_org_list' => [], 'admin_vss_list' => [] ]
+		);
+
+		$mechanicQueries = array_values( array_filter(
+			$result->queries,
+			fn( $q ) => str_contains( $q['sql'], 'm.id=?' )
+		) );
+
+		$this->assertCount( 1, $mechanicQueries, 'expected exactly one mechanic lookup query' );
+		$this->assertStringNotContainsString( self::TAINTED, $mechanicQueries[0]['sql'], 'the tainted value must not be spliced into the SQL text' );
+		$this->assertContains( self::TAINTED, $mechanicQueries[0]['params'] );
+	}
+}

--- a/tests/Integration/ModifyCharacterList3SqliTest.php
+++ b/tests/Integration/ModifyCharacterList3SqliTest.php
@@ -1,0 +1,30 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test confirming ModifyCharacterList3.php's character lookup
+ * binds the GET "modify" value as a query parameter rather than splicing it
+ * directly into the SQL string. This is the very first thing the page does,
+ * so a tainted "modify" value used to reach the database unescaped on every
+ * visit to this page.
+ *
+ * @see ModifyCharacterList3.php
+ */
+final class ModifyCharacterList3SqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "1' OR '1'='1";
+
+	/** The character lookup uses a "?" placeholder and binds the tainted value only as a parameter. */
+	public function testCharacterLookupIsParameterized(): void {
+		$result = PageHarness::run(
+			'ModifyCharacterList3.php',
+			get: [ 'modify' => self::TAINTED ]
+		);
+
+		$this->assertNotEmpty( $result->queries, 'expected at least one query to be captured' );
+		$query = $result->queries[0];
+		$this->assertStringContainsString( 'c.ID=?', $query['sql'] );
+		$this->assertStringNotContainsString( self::TAINTED, $query['sql'], 'the tainted value must not be spliced into the SQL text' );
+		$this->assertContains( self::TAINTED, $query['params'] );
+	}
+}

--- a/tests/Integration/ModifyCharacterXPList1SqliTest.php
+++ b/tests/Integration/ModifyCharacterXPList1SqliTest.php
@@ -1,0 +1,61 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression tests confirming ModifyCharacterXPList1.php's `earnedsort` and
+ * `spentsort` GET values -- spliced directly into an ORDER BY clause as
+ * column names, so they can never be `?`-parameterized -- are resolved
+ * through a strict whitelist before use: an unrecognized value falls back to
+ * the safe default column, while a real, whitelisted column name still
+ * passes through untouched.
+ *
+ * @see ModifyCharacterXPList1.php
+ */
+final class ModifyCharacterXPList1SqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED_EARNEDSORT = "eventname; DROP TABLE users";
+	private const TAINTED_SPENTSORT = "itembought; DROP TABLE users";
+
+	private const CHARACTER_ROW = [
+		'name'    => 'Test Character',
+		'subtype' => 'Vampire',
+		'venue'   => 'Test Venue',
+		'user_id' => '1',
+	];
+
+	/** A non-whitelisted earnedsort/spentsort falls back to the default column, never appearing in the ORDER BY clause. */
+	public function testUnrecognizedSortValuesFallBackToDefaultColumns(): void {
+		$result = PageHarness::run(
+			'ModifyCharacterXPList1.php',
+			get: [
+				'character_id' => '123',
+				'earnedsort'   => self::TAINTED_EARNEDSORT,
+				'spentsort'    => self::TAINTED_SPENTSORT,
+			],
+			session: [ 'admin_org_list' => [], 'admin_vss_list' => [] ],
+			responses: [ [ self::CHARACTER_ROW ] ]
+		);
+
+		$this->assertFalse( $result->anyQueryContains( self::TAINTED_EARNEDSORT ) );
+		$this->assertFalse( $result->anyQueryContains( self::TAINTED_SPENTSORT ) );
+		$this->assertTrue( $result->anyQueryContains( 'from earnedxp e where character_id=\'123\' order by earneddate desc' ) );
+		$this->assertTrue( $result->anyQueryContains( 'from spentxp s where character_id=\'123\' order by spentdate desc' ) );
+	}
+
+	/** A legitimate, whitelisted sort column is honored verbatim in the ORDER BY clause -- the whitelist doesn't just always fall back. */
+	public function testWhitelistedSortValuesAreHonoredVerbatim(): void {
+		$result = PageHarness::run(
+			'ModifyCharacterXPList1.php',
+			get: [
+				'character_id' => '123',
+				'earnedsort'   => 'xpearned',
+				'spentsort'    => 'itembought',
+			],
+			session: [ 'admin_org_list' => [], 'admin_vss_list' => [] ],
+			responses: [ [ self::CHARACTER_ROW ] ]
+		);
+
+		$this->assertTrue( $result->anyQueryContains( 'from earnedxp e where character_id=\'123\' order by xpearned asc' ) );
+		$this->assertTrue( $result->anyQueryContains( 'from spentxp s where character_id=\'123\' order by itembought asc' ) );
+	}
+}

--- a/tests/Integration/ModifyCharacterXPList2SqliTest.php
+++ b/tests/Integration/ModifyCharacterXPList2SqliTest.php
@@ -1,0 +1,36 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test confirming ModifyCharacterXPList2.php's bulk-delete branch
+ * binds every id in $_POST["delete"] -- an attacker-controlled array -- as
+ * its own `?` placeholder rather than splicing any of them into the SQL
+ * text, including the trailing `id!=?` exclusion built from $_POST["modify"].
+ *
+ * @see ModifyCharacterXPList2.php
+ */
+final class ModifyCharacterXPList2SqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "2' OR '1'='1";
+
+	/** Every id in the delete array -- including a tainted one -- is bound as a parameter, never spliced into the DELETE. */
+	public function testBulkDeleteBindsEveryIdAsParameter(): void {
+		$delete = [ '1', self::TAINTED, '3' ];
+
+		$result = PageHarness::run(
+			'ModifyCharacterXPList2.php',
+			post: [ 'xptype' => 'earned', 'delete' => $delete, 'character_id' => '777' ]
+		);
+
+		$deletes = array_values( array_filter(
+			$result->queries,
+			fn( $q ) => str_starts_with( $q['sql'], 'DELETE FROM' )
+		) );
+
+		$this->assertCount( 1, $deletes );
+		$this->assertStringNotContainsString( self::TAINTED, $deletes[0]['sql'], 'the tainted id must not be spliced into the SQL text' );
+		$this->assertSame( 'DELETE FROM earnedxp WHERE id IN (?,?,?) and id!=?', $deletes[0]['sql'] );
+		$this->assertCount( count( $delete ) + 1, $deletes[0]['params'], 'one placeholder per deleted id, plus one for the id!=? exclusion' );
+		$this->assertSame( array_merge( $delete, [ '' ] ), $deletes[0]['params'] );
+	}
+}

--- a/tests/Integration/ModifyCharacterXPList3SqliTest.php
+++ b/tests/Integration/ModifyCharacterXPList3SqliTest.php
@@ -1,0 +1,69 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression tests confirming ModifyCharacterXPList3.php no longer builds its
+ * lookup query from two unescaped $_GET values -- one of which (`table`) used
+ * to be spliced in as the table name itself, not just a value, so no amount
+ * of parameter binding alone could have fixed it. The fix binds `modify` as
+ * a `?` parameter AND resolves `table` through a strict whitelist
+ * ("earnedxp" or else "spentxp") before it ever reaches the SQL string.
+ *
+ * @see ModifyCharacterXPList3.php
+ */
+final class ModifyCharacterXPList3SqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED_ID = "1' OR '1'='1";
+	private const TAINTED_TABLE = "spentxp' OR '1'='1";
+
+	/** A tainted `modify` id is bound as a parameter against the legitimate "earnedxp" table. */
+	public function testEarnedxpLookupBindsTaintedIdAsParameter(): void {
+		$result = PageHarness::run(
+			'ModifyCharacterXPList3.php',
+			get: [ 'table' => 'earnedxp', 'modify' => self::TAINTED_ID ],
+			session: [ 'admin_org_list' => [], 'admin_vss_list' => [] ],
+			responses: [ [ [
+				'character_id' => '500',
+				'eventname'    => 'Test Event',
+				'earneddate'   => '2026-01-01',
+				'xpearned'     => '5',
+				'notes'        => 'Some notes',
+			] ] ]
+		);
+
+		$lookups = array_values( array_filter(
+			$result->queries,
+			fn( $q ) => str_starts_with( $q['sql'], 'select * from' )
+		) );
+
+		$this->assertCount( 1, $lookups );
+		$this->assertSame( 'select * from earnedxp where id=?', $lookups[0]['sql'] );
+		$this->assertSame( [ self::TAINTED_ID ], $lookups[0]['params'] );
+	}
+
+	/** An attempt to inject SQL via the `table` name itself is forced to the "spentxp" whitelist fallback, never spliced in raw. */
+	public function testTaintedTableNameFallsBackToWhitelistedSpentxp(): void {
+		$result = PageHarness::run(
+			'ModifyCharacterXPList3.php',
+			get: [ 'table' => self::TAINTED_TABLE, 'modify' => '5' ],
+			session: [ 'admin_org_list' => [], 'admin_vss_list' => [] ],
+			responses: [ [ [
+				'character_id' => '501',
+				'itembought'   => 'Sword',
+				'spentdate'    => '2026-02-01',
+				'xpspent'      => '3',
+				'notes'        => 'Bought weapon',
+			] ] ]
+		);
+
+		$lookups = array_values( array_filter(
+			$result->queries,
+			fn( $q ) => str_starts_with( $q['sql'], 'select * from' )
+		) );
+
+		$this->assertCount( 1, $lookups );
+		$this->assertStringNotContainsString( self::TAINTED_TABLE, $lookups[0]['sql'], 'the table-name whitelist must reject the injected identifier entirely, not just escape it' );
+		$this->assertSame( 'select * from spentxp where id=?', $lookups[0]['sql'] );
+		$this->assertSame( [ '5' ], $lookups[0]['params'] );
+	}
+}

--- a/tests/Integration/ModifyNPCList3SqliTest.php
+++ b/tests/Integration/ModifyNPCList3SqliTest.php
@@ -1,0 +1,30 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test confirming ModifyNPCList3.php's character lookup binds
+ * the GET "modify" value as a query parameter rather than splicing it
+ * directly into the SQL string. This mirrors ModifyCharacterList3.php's fix
+ * -- it is the very first thing the page does, so a tainted "modify" value
+ * used to reach the database unescaped on every visit to this page.
+ *
+ * @see ModifyNPCList3.php
+ */
+final class ModifyNPCList3SqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "1' OR '1'='1";
+
+	/** The character lookup uses a "?" placeholder and binds the tainted value only as a parameter. */
+	public function testCharacterLookupIsParameterized(): void {
+		$result = PageHarness::run(
+			'ModifyNPCList3.php',
+			get: [ 'modify' => self::TAINTED ]
+		);
+
+		$this->assertNotEmpty( $result->queries, 'expected at least one query to be captured' );
+		$query = $result->queries[0];
+		$this->assertStringContainsString( 'c.ID=?', $query['sql'] );
+		$this->assertStringNotContainsString( self::TAINTED, $query['sql'], 'the tainted value must not be spliced into the SQL text' );
+		$this->assertContains( self::TAINTED, $query['params'] );
+	}
+}

--- a/tests/Integration/ModifyOrgList3SqliTest.php
+++ b/tests/Integration/ModifyOrgList3SqliTest.php
@@ -1,0 +1,62 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test confirming ModifyOrgList3.php's two organization lookups
+ * both bind the GET "modify" value as a query parameter rather than
+ * splicing it directly into the SQL string.
+ *
+ * @see ModifyOrgList3.php
+ */
+final class ModifyOrgList3SqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "1' OR '1'='1";
+
+	/** Both organization lookups use a "?" placeholder and bind the tainted value only as a parameter. */
+	public function testOrganizationLookupsAreParameterized(): void {
+		// A non-empty row is needed at both lookup sites: the page redirects
+		// (and, at the second site, echoes an error and exits) if !$row.
+		$orgRow = [
+			'id' => 5,
+			'nation' => '',
+			'region' => '',
+			'domain' => '',
+			'chapter' => '',
+			'org_name' => 'Test Org',
+			'city' => '',
+			'state' => '',
+			'country' => '',
+			'email' => '',
+			'email_is_google' => 0,
+			'admin_user_id' => 0,
+			'active' => 1,
+		];
+
+		$result = PageHarness::run(
+			'ModifyOrgList3.php',
+			get: [ 'modify' => self::TAINTED ],
+			session: [
+				// Bypasses the "Super user OR assigned org admin" permission
+				// check, which would otherwise redirect before either query runs.
+				'super_user' => 1,
+				// header.inc's generateMenus() calls count() on these two
+				// session keys unconditionally; leaving them unset is a fatal
+				// TypeError under PHP 8, and header.inc runs before the queries.
+				'admin_org_list' => [],
+				'admin_vss_list' => [],
+			],
+			responses: [ [ $orgRow ], [ $orgRow ] ]
+		);
+
+		$orgQueries = array_values( array_filter(
+			$result->queries,
+			fn( $q ) => str_contains( $q['sql'], 'where id=?' )
+		) );
+
+		$this->assertCount( 2, $orgQueries, 'expected both organization lookups to run' );
+		foreach ( $orgQueries as $query ) {
+			$this->assertStringNotContainsString( self::TAINTED, $query['sql'], 'the tainted value must not be spliced into the SQL text' );
+			$this->assertContains( self::TAINTED, $query['params'] );
+		}
+	}
+}

--- a/tests/Integration/ModifyVenueList2SqliTest.php
+++ b/tests/Integration/ModifyVenueList2SqliTest.php
@@ -1,0 +1,34 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test confirming ModifyVenueList2.php's bulk-delete branch binds
+ * every id in $_POST["delete"] -- an attacker-controlled array -- as its own
+ * `?` placeholder rather than splicing any of them into the SQL text.
+ *
+ * @see ModifyVenueList2.php
+ */
+final class ModifyVenueList2SqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "20' OR '1'='1";
+
+	/** Every id in the delete array -- including a tainted one -- is bound as a parameter, never spliced into the DELETE. */
+	public function testBulkDeleteBindsEveryIdAsParameter(): void {
+		$delete = [ '10', self::TAINTED, '30' ];
+
+		$result = PageHarness::run(
+			'ModifyVenueList2.php',
+			post: [ 'delete' => $delete, 'modify' => '999' ]
+		);
+
+		$deletes = array_values( array_filter(
+			$result->queries,
+			fn( $q ) => str_starts_with( $q['sql'], 'DELETE FROM venues' )
+		) );
+
+		$this->assertCount( 1, $deletes );
+		$this->assertStringNotContainsString( self::TAINTED, $deletes[0]['sql'], 'the tainted id must not be spliced into the SQL text' );
+		$this->assertSame( 'DELETE FROM venues WHERE id IN (?,?,?)', $deletes[0]['sql'] );
+		$this->assertSame( $delete, $deletes[0]['params'] );
+	}
+}

--- a/tests/Integration/ModifyVenueList3SqliTest.php
+++ b/tests/Integration/ModifyVenueList3SqliTest.php
@@ -1,0 +1,32 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test confirming ModifyVenueList3.php's venue lookup binds the
+ * GET "modify" value as a query parameter rather than splicing it directly
+ * into the SQL string.
+ *
+ * @see ModifyVenueList3.php
+ */
+final class ModifyVenueList3SqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "1' OR '1'='1";
+
+	/** The venue lookup uses a "?" placeholder and binds the tainted value only as a parameter. */
+	public function testVenueLookupIsParameterized(): void {
+		$result = PageHarness::run(
+			'ModifyVenueList3.php',
+			get: [ 'modify' => self::TAINTED ],
+			// header.inc's generateMenus() calls count() on these two session
+			// keys unconditionally; leaving them unset is a fatal TypeError
+			// under PHP 8, and header.inc runs before the venue query.
+			session: [ 'admin_org_list' => [], 'admin_vss_list' => [] ]
+		);
+
+		$this->assertNotEmpty( $result->queries, 'expected at least one query to be captured' );
+		$query = $result->queries[0];
+		$this->assertStringContainsString( 'where ID=?', $query['sql'] );
+		$this->assertStringNotContainsString( self::TAINTED, $query['sql'], 'the tainted value must not be spliced into the SQL text' );
+		$this->assertContains( self::TAINTED, $query['params'] );
+	}
+}

--- a/tests/Integration/MoveCharacter2SqliTest.php
+++ b/tests/Integration/MoveCharacter2SqliTest.php
@@ -1,0 +1,69 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression tests confirming MoveCharacter2.php's organizations/vsss
+ * storyteller lookup -- chosen by the sign of the resolved VSS selection --
+ * binds that id as a `?` parameter instead of splicing it into the SQL
+ * text. resolveVssSelection() (include/vss_selection.inc) always returns
+ * form input as a plain string and this fix casts it with (int) before use,
+ * so this particular value can't actually carry an injection payload in
+ * practice; the point of these tests is to prove the identifier position is
+ * safe regardless, and that the sign correctly routes to the right table.
+ *
+ * Setting $_SESSION['user_id'] also pulls in db.inc's own session_setup.inc
+ * bootstrap as a side effect, which issues five queries of its own first --
+ * hence the five leading empty placeholders in `responses` before the
+ * character row -- and this page's own already-parameterized `characters`
+ * lookup runs before the query under test, so the assertions filter
+ * `->queries` for the specific statement rather than assuming a fixed index.
+ *
+ * @see MoveCharacter2.php
+ */
+final class MoveCharacter2SqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const CHARACTER_ROW = [
+		'player_id' => '0', // 0 => NPC, so the player lookup branch is skipped and the test stays focused on the fixed query
+		'vss_id'    => '0',
+		'name'      => 'Test Character',
+		'subtype'   => 'Vampire',
+	];
+
+	/** A negative resolved VSS selection (a local-org pick) looks up the organization's admin user, binding the negated id as a parameter. */
+	public function testNegativeVssSelectionQueriesOrganizationsWithBoundId(): void {
+		$result = PageHarness::run(
+			'MoveCharacter2.php',
+			post: [ 'localvss_id' => '-995', 'totalvss_id' => '', 'char_id' => '500', 'redirect' => '' ],
+			session: [ 'user_id' => 42 ],
+			responses: [ [], [], [], [], [], [ self::CHARACTER_ROW ] ]
+		);
+
+		$lookups = array_values( array_filter(
+			$result->queries,
+			fn( $q ) => str_starts_with( $q['sql'], 'SELECT u.* FROM organizations' )
+		) );
+
+		$this->assertCount( 1, $lookups );
+		$this->assertSame( 'SELECT u.* FROM organizations o LEFT JOIN users u ON u.id = o.admin_user_id WHERE o.id=?', $lookups[0]['sql'] );
+		$this->assertSame( [ 995 ], $lookups[0]['params'] );
+	}
+
+	/** A positive resolved VSS selection (a total-org pick) looks up the VSS's storyteller, binding the id as a parameter. */
+	public function testPositiveVssSelectionQueriesVsssWithBoundId(): void {
+		$result = PageHarness::run(
+			'MoveCharacter2.php',
+			post: [ 'localvss_id' => '', 'totalvss_id' => '1312', 'char_id' => '500', 'redirect' => '' ],
+			session: [ 'user_id' => 42 ],
+			responses: [ [], [], [], [], [], [ self::CHARACTER_ROW ] ]
+		);
+
+		$lookups = array_values( array_filter(
+			$result->queries,
+			fn( $q ) => str_starts_with( $q['sql'], 'SELECT u.* FROM vsss' )
+		) );
+
+		$this->assertCount( 1, $lookups );
+		$this->assertSame( 'SELECT u.* FROM vsss v LEFT JOIN users u ON u.id = v.storyteller_id WHERE v.id=?', $lookups[0]['sql'] );
+		$this->assertSame( [ 1312 ], $lookups[0]['params'] );
+	}
+}

--- a/tests/Integration/PageHarness.php
+++ b/tests/Integration/PageHarness.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Runs a real top-level application page/include in an isolated child PHP
+ * process against a fully in-memory stub database, and reports back every
+ * SQL statement + bound params the page issued.
+ *
+ * Why a child process rather than an in-process include (as tests/Unit/
+ * does for classes): these are legacy procedural scripts that call
+ * header()/exit()/die() directly and read superglobals at the top level.
+ * Isolating each run in its own process means an exit() call only ends that
+ * child -- it can never take down the PHPUnit run -- while a shutdown
+ * function inside the child still reliably flushes captured queries even
+ * after a fatal error or an explicit exit().
+ *
+ * The real db.inc, header.inc, DAOFactory, and every DAO class run
+ * completely unmodified; only include/Database.class.php and
+ * include/settings.inc are shadowed (via -d include_path, which PHP checks
+ * before a bare include's calling-script directory) with an in-memory
+ * recorder. See stub_includes/include/Database.class.php.
+ *
+ * @see PageHarnessResult
+ */
+class PageHarness {
+
+    /**
+     * @param string $page Path to the target file, relative to the repo root (e.g. "footerbar.inc", "UserDisplay.php").
+     * @param array $get Populates $_GET before the page is included.
+     * @param array $post Populates $_POST before the page is included.
+     * @param array $session Populates $_SESSION before the page is included (after the harness's own session_start(), so it isn't reset).
+     * @param bool $ignoreLogin When true (default), sets a global $IGNORE_LOGIN so header.inc's login gate lets the request through without needing $_SESSION['user_id'] set (which would also trigger the separate, heavier session_setup.inc bootstrap). Set false only when specifically testing login-gate behavior.
+     * @param array $responses Canned row sets returned by successive $db->query() calls, in call order (FIFO) -- each entry is a list of associative-array rows for one query; a query beyond the queued responses gets an empty result.
+     * @return PageHarnessResult The captured queries, any header() calls, and the page's raw output/exit code.
+     * @throws RuntimeException if the child process cannot be started at all (a non-zero exit from the page itself is NOT an error -- that's normal for pages that redirect/die).
+     */
+    public static function run(
+        string $page,
+        array $get = [],
+        array $post = [],
+        array $session = [],
+        bool $ignoreLogin = true,
+        array $responses = []
+    ): PageHarnessResult {
+        $repoRoot = dirname( __DIR__, 2 );
+        $specFile = tempnam( sys_get_temp_dir(), 'aph_spec_' );
+        $outFile  = tempnam( sys_get_temp_dir(), 'aph_out_' );
+
+        file_put_contents( $specFile, json_encode( [
+            'page'        => $page,
+            'get'         => $get,
+            'post'        => $post,
+            'session'     => $session,
+            'ignoreLogin' => $ignoreLogin,
+            'responses'   => $responses,
+            'outFile'     => $outFile,
+        ] ) );
+
+        $driver = __DIR__ . DIRECTORY_SEPARATOR . 'driver.php';
+        $stubPath = __DIR__ . DIRECTORY_SEPARATOR . 'stub_includes';
+
+        $cmd = escapeshellarg( PHP_BINARY )
+            . ' -d include_path=' . escapeshellarg( $stubPath )
+            . ' -d error_reporting=' . escapeshellarg( (string)( E_ALL & ~E_DEPRECATED ) )
+            . ' -d display_errors=1'
+            . ' -d session.save_path=' . escapeshellarg( sys_get_temp_dir() )
+            . ' ' . escapeshellarg( $driver )
+            . ' ' . escapeshellarg( $specFile );
+
+        $descriptors = [ 1 => [ 'pipe', 'w' ], 2 => [ 'pipe', 'w' ] ];
+        $process = proc_open( $cmd, $descriptors, $pipes, $repoRoot );
+        if ( !is_resource( $process ) ) {
+            @unlink( $specFile );
+            @unlink( $outFile );
+            throw new RuntimeException( "PageHarness: failed to start child process for $page" );
+        }
+
+        $stdout = stream_get_contents( $pipes[1] );
+        $stderr = stream_get_contents( $pipes[2] );
+        fclose( $pipes[1] );
+        fclose( $pipes[2] );
+        $exitCode = proc_close( $process );
+
+        $captured = [];
+        if ( is_file( $outFile ) ) {
+            $captured = json_decode( file_get_contents( $outFile ), true ) ?? [];
+            @unlink( $outFile );
+        }
+        @unlink( $specFile );
+
+        return new PageHarnessResult(
+            $captured['queries'] ?? [],
+            $captured['headers'] ?? [],
+            $stdout,
+            $stderr,
+            $exitCode
+        );
+    }
+}
+
+/** Result of one PageHarness::run() call. */
+class PageHarnessResult {
+    /** @param array $queries Each entry: ['sql' => string, 'params' => array, 'db' => string]. */
+    public function __construct(
+        public readonly array $queries,
+        public readonly array $headers,
+        public readonly string $output,
+        public readonly string $stderr,
+        public readonly int $exitCode
+    ) {}
+
+    /** The SQL text of every captured query, in call order. */
+    public function sqlStatements(): array {
+        return array_column( $this->queries, 'sql' );
+    }
+
+    /** True if any captured query's SQL text contains $needle verbatim (e.g. to assert a raw value was NOT interpolated). */
+    public function anyQueryContains( string $needle ): bool {
+        foreach ( $this->sqlStatements() as $sql ) {
+            if ( str_contains( $sql, $needle ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** True if any captured query's params array contains $needle as one of its bound values. */
+    public function anyParamsContain( mixed $needle ): bool {
+        foreach ( $this->queries as $q ) {
+            if ( in_array( $needle, $q['params'], true ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/tests/Integration/VSSDetailsSqliTest.php
+++ b/tests/Integration/VSSDetailsSqliTest.php
@@ -1,0 +1,33 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test confirming VSSDetails.php's VSS lookup binds the GET "id"
+ * value as a query parameter rather than splicing it directly into the SQL
+ * string. header.inc runs before this query (unlike UserDisplay.php's
+ * DeleteST action), so $IGNORE_LOGIN is what lets the request through.
+ *
+ * @see VSSDetails.php
+ */
+final class VSSDetailsSqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "1' OR '1'='1";
+
+	/** The VSS lookup uses a "?" placeholder and binds the tainted value only as a parameter. */
+	public function testVssLookupIsParameterized(): void {
+		$result = PageHarness::run(
+			'VSSDetails.php',
+			get: [ 'id' => self::TAINTED ],
+			// header.inc's generateMenus() calls count() on these two session
+			// keys unconditionally; leaving them unset is a fatal TypeError
+			// under PHP 8, and header.inc runs before the VSS query.
+			session: [ 'admin_org_list' => [], 'admin_vss_list' => [] ]
+		);
+
+		$this->assertNotEmpty( $result->queries, 'expected at least one query to be captured' );
+		$query = $result->queries[0];
+		$this->assertStringContainsString( 'WHERE v.id=?', $query['sql'] );
+		$this->assertStringNotContainsString( self::TAINTED, $query['sql'], 'the tainted value must not be spliced into the SQL text' );
+		$this->assertContains( self::TAINTED, $query['params'] );
+	}
+}

--- a/tests/Integration/driver.php
+++ b/tests/Integration/driver.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Standalone child-process driver for PageHarness::run().
+ *
+ * Reads a JSON spec (argv[1]) describing $_GET/$_POST/$_SESSION and canned
+ * DB row responses, then includes the target application page under those
+ * conditions with include_path shadowing the real Database class (see
+ * stub_includes/include/Database.class.php) -- every other included file
+ * (db.inc, header.inc, DAOFactory, every DAO class) is the real, unmodified
+ * application code. Captures every query issued to the stub $db and, via a
+ * shutdown function (so it still fires if the page calls exit()/die() or
+ * hits a fatal error), writes them to the spec's outFile as JSON.
+ *
+ * Never run directly -- always invoked by PageHarness::run() as a php -d
+ * include_path=... child process with cwd set to the repo root.
+ */
+
+$specFile = $argv[1] ?? null;
+if ( !$specFile || !is_file( $specFile ) ) {
+    fwrite( STDERR, "driver.php: missing or unreadable spec file\n" );
+    exit( 2 );
+}
+$spec = json_decode( file_get_contents( $specFile ), true );
+if ( !is_array( $spec ) ) {
+    fwrite( STDERR, "driver.php: spec file did not contain valid JSON\n" );
+    exit( 2 );
+}
+
+$GLOBALS['__captured_queries'] = [];
+$GLOBALS['__stub_responses'] = $spec['responses'] ?? [];
+
+register_shutdown_function( function () use ( $spec ) {
+    $out = [
+        'queries' => $GLOBALS['__captured_queries'] ?? [],
+        'headers' => function_exists( 'headers_list' ) ? headers_list() : [],
+    ];
+    file_put_contents( $spec['outFile'], json_encode( $out ) );
+} );
+
+$_GET = $spec['get'] ?? [];
+$_POST = $spec['post'] ?? [];
+
+// Start the session ourselves first so real db.inc's own
+// `if (session_status() === PHP_SESSION_NONE) { session_start(); }` guard
+// sees an already-active session and skips re-starting it -- otherwise
+// CLI's session_start() would reset $_SESSION back to empty.
+session_start();
+$_SESSION = $spec['session'] ?? [];
+
+if ( !empty( $spec['ignoreLogin'] ) ) {
+    // header.inc's login gate is `!isset($_SESSION['user_id']) && !isset($IGNORE_LOGIN)`;
+    // setting this lets tests exercise pages that sit behind that gate without
+    // needing $_SESSION['user_id'] set (which would also pull in the much
+    // heavier session_setup.inc bootstrap via db.inc).
+    $GLOBALS['IGNORE_LOGIN'] = 1;
+}
+
+include getcwd() . '/' . $spec['page'];

--- a/tests/Integration/stub_includes/include/Database.class.php
+++ b/tests/Integration/stub_includes/include/Database.class.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Stub replacement for include/Database.class.php, used ONLY by the
+ * Integration test harness (tests/Integration/PageHarness.php) via PHP's
+ * include_path resolution: a bare `include_once("include/Database.class.php")`
+ * checks include_path before the calling script's own directory, so pointing
+ * php's -d include_path at this file's parent directory makes every real
+ * application file (db.inc, DAOFactory, every DAO class) transparently talk
+ * to this in-memory recorder instead of a real MySQL connection.
+ *
+ * Every query passed to Database::query() is appended to a global capture
+ * list (read back by the harness after the driver process exits) instead of
+ * being executed, and returns a canned row set popped from a global queue the
+ * driver script populates from the test's fixture file. No network I/O, no
+ * real settings.inc, no real mysqli extension calls.
+ */
+
+class Database {
+    public $db_host;
+    public $db_user;
+    public $db_pass;
+    public $db_name;
+    public $dbh;
+    public $lastResult;
+
+    public function __construct( $host = null, $user = null, $pass = null, $name = null ) {
+        $this->db_host = $host;
+        $this->db_user = $user;
+        $this->db_pass = $pass;
+        $this->db_name = $name;
+        $this->dbh = null;
+    }
+
+    /** Mirrors the real class's escape() shape; no real mysqli handle exists, so this is a plain fallback. */
+    function escape( $source ) {
+        return addslashes( (string)$source );
+    }
+
+    /**
+     * Records the query instead of running it, and returns the next canned
+     * row set queued for this connection (FIFO), defaulting to an empty
+     * result when the test didn't queue one for this call.
+     */
+    function query( string $query, array $params = [] ) {
+        $GLOBALS['__captured_queries'][] = [ 'sql' => $query, 'params' => $params, 'db' => $this->db_name ];
+        $rows = array_shift( $GLOBALS['__stub_responses'] ) ?? [];
+        $this->lastResult = new StubResultSet( $rows );
+        return $this->lastResult;
+    }
+
+    function throwError() {
+        // Real class echoes debug info then exit()s on a query failure.
+        // The stub never fails a query, so this should never be reached.
+        exit( 1 );
+    }
+
+    function getAllRows() { return $this->lastResult->getAllRows(); }
+    function getFieldCount() { return $this->lastResult->getFieldCount(); }
+    function getFieldNames() { return $this->lastResult->getFieldNames(); }
+    function nextRow() { return $this->lastResult->nextRow(); }
+    function numRows() { return $this->lastResult->numRows(); }
+    function affectedRows() { return $this->lastResult->affectedRows(); }
+    function getField( $field ) { return $this->lastResult->getField( $field ); }
+    function getInsertId() { return 1; }
+}
+
+/** Mirrors include/ResultSet.class.php's public interface over a plain PHP array of assoc rows -- no mysqli_result involved. */
+class StubResultSet {
+    private $rows;
+    private $currentRow = 0;
+
+    public function __construct( array $rows ) {
+        $this->rows = array_values( $rows );
+    }
+
+    function getFieldCount() { return count( $this->rows ) > 0 ? count( $this->rows[0] ) : 0; }
+    function getFieldNames() { return count( $this->rows ) > 0 ? array_keys( $this->rows[0] ) : []; }
+
+    function nextRow() {
+        if ( isset( $this->rows[$this->currentRow] ) ) {
+            return $this->rows[$this->currentRow++];
+        }
+        return array();
+    }
+
+    function numRows() { return count( $this->rows ); }
+    function affectedRows() { return 0; }
+    function getField( $field ) { return $this->rows[$this->currentRow][$field] ?? null; }
+    function getAllRows() { return $this->rows; }
+}

--- a/tests/Integration/stub_includes/include/settings.inc
+++ b/tests/Integration/stub_includes/include/settings.inc
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Stub replacement for include/settings.inc, used only by the Integration
+ * test harness via include_path shadowing (see stub_includes/include/Database.class.php
+ * for the mechanism). Values are dummy placeholders -- the stub Database
+ * class never actually connects to them.
+ */
+
+$SETTINGS = array();
+
+$SETTINGS["APPROVALS_SERVER"]   = "stub";
+$SETTINGS["APPROVALS_USERNAME"] = "stub";
+$SETTINGS["APPROVALS_PASSWORD"] = "stub";
+$SETTINGS["APPROVALS_DATABASE"] = "approvals_2017";
+
+$SETTINGS["PORTAL_SERVER"]      = "stub";
+$SETTINGS["PORTAL_USERNAME"]    = "stub";
+$SETTINGS["PORTAL_PASSWORD"]    = "stub";
+$SETTINGS["PORTAL_DATABASE"]    = "mes-portal";
+
+$SETTINGS["OAUTH_CLIENT_ID"]     = "stub";
+$SETTINGS["OAUTH_CLIENT_SECRET"] = "stub";
+$SETTINGS["OAUTH_REDIRECT_URI"]  = "https://example.test/oauth_callback.php";
+$SETTINGS["OAUTH_TOKEN_URL"]     = "https://example.test/oauth/v2/token";
+$SETTINGS["OAUTH_API_URL"]       = "https://example.test/api/authorized/user.json";
+
+$SETTINGS["EARLY_ACCESS_ENABLED"] = false;
+$SETTINGS["GOOGLE_MAP_SYNC_ENABLED"] = false;

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,21 +17,58 @@ tools\get-phpunit.ps1       # Windows PowerShell
 ## Running
 
 ```bash
-php tools/phpunit.phar                    # all suites (config: phpunit.xml)
-php tools/phpunit.phar --testsuite unit   # unit suite only
+php tools/phpunit.phar                          # all suites (config: phpunit.xml)
+php tools/phpunit.phar --testsuite unit         # unit suite only
+php tools/phpunit.phar --testsuite integration  # integration suite only
 ```
 
 ## Layout
 
 - `tests/Unit/` — fast, offline unit tests. They inject **stub doubles** for DAOs, so
   they need no database and never load `include/settings.inc`. See `tests/bootstrap.php`.
+  `tests/Unit/support/` holds shared test doubles (not test files themselves) — e.g.
+  `RecordingDb.php`, a stand-in `Database` that records every `query($sql, $params)`
+  call, used by the SQL-injection regression tests to assert a query uses `?`
+  placeholders and that a tainted value only ever appears in `$params`.
+- `tests/Integration/` — runs a real top-level page/include (not just a class) in an
+  **isolated child PHP process** via `PageHarness::run()`, against an in-memory stub
+  `Database` (`tests/Integration/stub_includes/`) — still fully offline, no real
+  database. This exists because many of this app's page scripts are top-level
+  procedural code that calls `header()`/`exit()` directly and reads `$_GET`/`$_POST`/
+  `$_SESSION` — not unit-testable in-process the way a class is. Process isolation
+  means an `exit()` inside the target page only ends that child process; a shutdown
+  function in the child still flushes captured queries even after a fatal error.
+  The mechanism: only `include/Database.class.php` and `include/settings.inc` are
+  shadowed via PHP's `include_path` (checked before a bare include's calling-script
+  directory) — the real `db.inc`, `header.inc`, `DAOFactory`, and every DAO class run
+  completely unmodified against the stub connection.
+  **Known gap:** any page that transitively includes `application.inc` (which
+  `require_once`s Smarty from a hardcoded absolute Linux path,
+  `/usr/share/php/smarty3/SmartyBC.class.php`) cannot run under this harness on a
+  machine without that exact path — absolute-path includes bypass `include_path`
+  shadowing entirely. Those pages currently rely on the manual QA steps in their
+  PR's test plan instead.
 - `tests/test_final_approval.php` — a pre-existing self-contained **live-DB integration**
   script (its own assert harness). Run directly: `php tests/test_final_approval.php`.
-  It is not part of the `unit` suite because it requires DB connectivity and fixtures.
+  It is not part of either suite because it requires DB connectivity and fixtures.
 
 ## Writing a unit test
 
 `require_once` the app file under test at the top (the bootstrap has already `chdir`'d to
 the repo root), then inject anonymous-class stubs for its collaborators. Example pattern:
 `tests/Unit/GetLowSTTest.php` constructs `ApplicationService` with four stub DAOs and asserts
-the resolved storyteller id for each `vss_id` branch.
+the resolved storyteller id for each `vss_id` branch. For a query-building test, use
+`tests/Unit/support/RecordingDb.php` instead of an ad hoc stub — see
+`tests/Unit/UserInfoDAOSqliTest.php` for the pattern.
+
+## Writing an integration (page-script) test
+
+`require_once 'tests/Integration/PageHarness.php'`, then call
+`PageHarness::run($page, get: [...], post: [...], session: [...], responses: [...])`
+and assert on the returned `PageHarnessResult` (`->queries`, `->sqlStatements()`,
+`->anyQueryContains()`, `->anyParamsContain()`, `->exitCode`). `ignoreLogin` defaults to
+`true`, bypassing `header.inc`'s login gate without needing `$_SESSION['user_id']` set
+(which would also trigger the heavier `session_setup.inc` bootstrap) — pass `false` only
+when specifically testing login-gate behavior. `responses` supplies one row-array per
+expected `$db->query()` call, in call order; a call beyond the queued responses gets an
+empty result. See `tests/Integration/FooterbarSqliTest.php` for the pattern.

--- a/tests/Unit/support/RecordingDb.php
+++ b/tests/Unit/support/RecordingDb.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Minimal stand-in for the real Database class, shared by the SQL-injection
+ * regression tests: records every SQL string and bound params array passed
+ * to query(), and returns a canned row set (or none) so a test can assert
+ * the query text uses ?-placeholders and that a tainted value only ever
+ * appears in $params, never spliced into $sql.
+ *
+ * @see Database in include/Database.class.php, the real class this doubles for.
+ */
+class RecordingDb {
+	/** @var array<int, array{sql: string, params: array}> Every query() call, in order. */
+	public array $queries = [];
+
+	private array $responses;
+	private array $lastRows = [];
+	private int $cursor = 0;
+
+	/** @param array $responses One row-array per expected query() call, in call order (FIFO). A call beyond the queued responses gets no rows. */
+	public function __construct( array $responses = [] ) {
+		$this->responses = $responses;
+	}
+
+	public function query( string $sql, array $params = [] ) {
+		$this->queries[] = [ 'sql' => $sql, 'params' => $params ];
+		$this->lastRows = array_shift( $this->responses ) ?? [];
+		$this->cursor = 0;
+		return $this;
+	}
+
+	public function escape( $value ) {
+		return addslashes( (string)$value );
+	}
+
+	public function nextRow() {
+		if ( isset( $this->lastRows[ $this->cursor ] ) ) {
+			return $this->lastRows[ $this->cursor++ ];
+		}
+		return array();
+	}
+
+	public function numRows(): int {
+		return count( $this->lastRows );
+	}
+
+	public function getAllRows(): array {
+		return $this->lastRows;
+	}
+
+	/** The SQL text of every query() call, in order. */
+	public function sqlStatements(): array {
+		return array_column( $this->queries, 'sql' );
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #34, Fixes #35, Fixes #36, Fixes #37, Fixes #38, Fixes #39, Fixes #40, Fixes #41, Fixes #42, Fixes #43, Fixes #44, Fixes #45, Fixes #46 — PR 2 of 3 in the SQL injection remediation plan (see #52 for PR 1, the highest-severity batch).

- **Id-based lookups**, raw `$_GET`/`$row[...]` interpolated into WHERE clauses: `ModifyCharacterList3.php`, `ModifyNPCList3.php`, `ModifyVenueList3.php`, `ModifyOrgList3.php` (two query sites), `MechanicsDetails.php`, `EventsDetails.php`, `VSSDetails.php`, `DisplayCharacter.php` (SELECT + INSERT).
- **Destructive DELETEs** built from raw POST arrays: `ModifyCharacterXPList2.php`, `ModifyVenueList2.php` — converted to placeholder IN-lists.
- **`MoveCharacter2.php`**: unvalidated `$vss_id` (from `resolveVssSelection()` on raw POST) spliced into two queries — now cast to `(int)` and parameterized.
- **Two dynamic-identifier cases** placeholders alone can't fix:
  - `ModifyCharacterXPList3.php` took its table name straight from `$_GET["table"]` before using it as a literal identifier — now whitelisted to `earnedxp`/`spentxp`, matching this file's own existing ternary logic for the same distinction.
  - `ModifyCharacterXPList1.php` spliced `$_GET["earnedsort"]`/`["spentsort"]` directly into `ORDER BY` as column names — now whitelisted against each table's real column set.

All value-position fixes use the `?`/`$params` support `include/Database.class.php` already provides, matching PR #52's pattern.

## Test plan
- [x] `php -l` on all 13 files — no syntax errors
- [ ] Spot-check a few of the "modify" pages (character, NPC, venue, org) still load and save correctly for a valid id
- [ ] Confirm `ModifyCharacterXPList1.php`'s sort-by-column links still sort correctly for every column
- [ ] Confirm bulk-delete on the XP list and venue list pages still works
- [ ] Tail `/var/log/nginx/legacy_error.log` after deploy for any new SQL-related fatals