### PR TITLE
fix: harden DAO/service-layer queries to parameterized style (security)

### DIFF
--- a/AppDetailsTopSection.php
+++ b/AppDetailsTopSection.php
@@ -52,15 +52,12 @@ if( is_object( $app_info->character ) ) {
 $affiliation = $organizationDAO->readByID( $vss_org_id );
 
 if( $affiliation->chapter ) {
-	$res = $db->query( sprintf(
+	$res = $db->query(
 		"SELECT admin_user_id ".
 		"FROM organizations ".
-		"WHERE chapter='%s' AND domain='%s' AND region='%s' AND nation='%s'",
-		$db->escape($affiliation->chapter),
-		$db->escape($affiliation->domain),
-		$db->escape($affiliation->region),
-		$db->escape($affiliation->nation)
-	));
+		"WHERE chapter=? AND domain=? AND region=? AND nation=?",
+		[$affiliation->chapter, $affiliation->domain, $affiliation->region, $affiliation->nation]
+	);
 	if( $row=$res->nextRow() && $row['admin_user_id'] != '') {
 		$storytellers[] = array(
   			'title' => 'CST',
@@ -69,13 +66,11 @@ if( $affiliation->chapter ) {
 	}
 }
 if( $affiliation->domain ) {
-	$res = $db->query( sprintf(
+	$res = $db->query(
 		"SELECT admin_user_id FROM organizations o ".
-		"WHERE o.chapter='' and o.domain='%s' and o.region='%s' and o.nation='%s'",
-		$db->escape( $affiliation->domain ),
-		$db->escape( $affiliation->region ),
-		$db->escape( $affiliation->nation )
-	));
+		"WHERE o.chapter='' and o.domain=? and o.region=? and o.nation=?",
+		[$affiliation->domain, $affiliation->region, $affiliation->nation]
+	);
 	if( $row=$res->nextRow() ) {
   		$storytellers[] = array(
   			'title' => 'DST',
@@ -84,12 +79,11 @@ if( $affiliation->domain ) {
 	}
 }
 if( $affiliation->region ) {
-	$res = $db->query( sprintf(
+	$res = $db->query(
 		"SELECT admin_user_id FROM organizations o ".
-		"WHERE o.chapter='' and o.domain='' and o.region='%s' and o.nation='%s'",
-		$db->escape( $affiliation->region ),
-		$db->escape( $affiliation->nation )
-	));
+		"WHERE o.chapter='' and o.domain='' and o.region=? and o.nation=?",
+		[$affiliation->region, $affiliation->nation]
+	);
 	if( $row=$res->nextRow() ) {
  		$storytellers[] = array(
   			'title' => 'RST',
@@ -98,11 +92,11 @@ if( $affiliation->region ) {
 	}
 }
 if( $affiliation->nation ) {
-	$res = $db->query( sprintf(
+	$res = $db->query(
 		"SELECT admin_user_id FROM organizations o ".
-		"WHERE o.chapter='' and o.domain='' and o.region='' and o.nation='%s'",
-		$db->escape( $affiliation->nation )
-	));
+		"WHERE o.chapter='' and o.domain='' and o.region='' and o.nation=?",
+		[$affiliation->nation]
+	);
 	if( $row=$res->nextRow() ) {
  		$storytellers[] = array(
   			'title' => 'NST',

--- a/ModifyCategoryList3.php
+++ b/ModifyCategoryList3.php
@@ -3,10 +3,10 @@
 	$pagetitle="Modify Category";
 include_once('application.inc');
 	$category_id = $_GET['modify'];
-	$db->query(sprintf("SELECT * FROM categories WHERE id=%d", $category_id ) );
+	$db->query("SELECT * FROM categories WHERE id=?", [$category_id]);
 	$category = $db->nextRow();
 
-	$db->query(sprintf("SELECT venue_id FROM category_venue WHERE category_id=%d", $category_id ) );
+	$db->query("SELECT venue_id FROM category_venue WHERE category_id=?", [$category_id]);
 	$venues = array();
 	while( $row = $db->nextRow() ) {
 	  array_push( $venues, $row["venue_id"] );

--- a/classes/ApplicationDAO.php
+++ b/classes/ApplicationDAO.php
@@ -241,6 +241,7 @@ class ApplicationDAO {
 			$where_params = [$user_id];
 			if ( sizeof($admin_org_venue_list) > 0 ) {
 				foreach( $admin_org_venue_list as $venue_id => $admin_org_list ) {
+					$venue_id = (int)$venue_id;
 					$temp = "create temporary table user_orgids{$venue_id} (orgid int not null, PRIMARY KEY (`orgid`)) ENGINE=Memory";
 					if($echoquery) echo $temp."\n";
 					$this->db->query($temp);

--- a/classes/UserInfoDAO.php
+++ b/classes/UserInfoDAO.php
@@ -12,16 +12,17 @@ class UserInfoDAO {
 	}
 
 	function updateLastLoginDate( $id ) {
-		$query = "UPDATE users SET last_login_date = now() WHERE id=%d";
 		if( isset( $this->_CACHE[$id] ) ) {
 			$this->_CACHE[$id]['last_login_date'] = getdate();
 		}
-		$this->db->query( sprintf( $query, $id ) );
+		$this->db->query( "UPDATE users SET last_login_date = now() WHERE id=?", [$id] );
 	}
 
 	function readApprovalsDBInfo( $id ) {
-		$query = "SELECT ww_number, super_user, org_id, email, name, unix_timestamp(last_login_date) as last_login_date FROM users WHERE id=%d";
-		$res = $this->db->query(sprintf($query,$id));
+		$res = $this->db->query(
+			"SELECT ww_number, super_user, org_id, email, name, unix_timestamp(last_login_date) as last_login_date FROM users WHERE id=?",
+			[$id]
+		);
 		return $res->nextRow();
 	}
 
@@ -31,11 +32,10 @@ class UserInfoDAO {
 	 */
 	function readPortalUserInfo( $memnumber ) {
 		if( $this->portal_db != null ) {
-			$query =
-				"SELECT firstName, lastName, emailAddress " .
-				"FROM User " .
-				"WHERE membershipNumber = '%s'";
-			$res = $this->portal_db->query(sprintf($query,mysqli_escape_string($this->portal_db->dbh,$memnumber)));
+			$res = $this->portal_db->query(
+				"SELECT firstName, lastName, emailAddress FROM User WHERE membershipNumber = ?",
+				[$memnumber]
+			);
 			if( $res !== false && $res->numRows() > 0 ) {
 				return $res->nextRow();
 			}
@@ -61,8 +61,10 @@ function isMemberActiveByWwNumber( $ww_number ) {
         return false;
     }
 
-    $query = "SELECT membershipExpiration FROM User WHERE membershipNumber = '%s'";
-    $res = $this->portal_db->query(sprintf($query, mysqli_escape_string($this->portal_db->dbh, $ww_number)));
+    $res = $this->portal_db->query(
+        "SELECT membershipExpiration FROM User WHERE membershipNumber = ?",
+        [$ww_number]
+    );
     if( $res !== false && $res->numRows() > 0 ) {
         $row = $res->nextRow();
         $expiration = $row['membershipExpiration'];
@@ -92,8 +94,7 @@ function isMemberActive( $user_id ) {
 
 	function getVSTPositions( $userID ) {
 		$positions = array();
-		$query = "SELECT name FROM vsss WHERE storyteller_id=%d";
-		$res = $this->db->query(sprintf($query, $userID));
+		$res = $this->db->query("SELECT name FROM vsss WHERE storyteller_id=?", [$userID]);
 		while( $row = $res->nextRow() ) {
 			$positions[] = "VST for " . $row["name"];
 		}
@@ -108,8 +109,8 @@ function isMemberActive( $user_id ) {
 			"FROM storytellers s ".
 			"LEFT JOIN organizations o ON s.organization_id = o.id ".
 			"LEFT JOIN venues v ON s.venue_id = v.id ".
-			"WHERE s.user_id=%d";
-		$res = $this->db->query(sprintf($query,$userID));
+			"WHERE s.user_id=?";
+		$res = $this->db->query($query, [$userID]);
 		while( $row = $res->nextRow() ) {
 			$position = '';
 			if( $row['assistant'] ) {
@@ -229,8 +230,8 @@ function isMemberActive( $user_id ) {
 		$swap_ids = array();
 		$query="SELECT u.username, u.id ".
 			"FROM users u ".
-			"WHERE u.ww_number='%s'";
-		$res = $this->db->query(sprintf($query, $this->db->escape( $cam_number ) ) );
+			"WHERE u.ww_number=?";
+		$res = $this->db->query($query, [$cam_number]);
 		if ($res->numRows() > 1) {
 			while($swap_id = $res->nextRow()) {
 				$swap_ids[] = $swap_id;
@@ -243,13 +244,13 @@ function isMemberActive( $user_id ) {
 		if( count($organization_ids) == 0 ) {
 			return false;
 		}
+		$placeholders = implode(",", array_fill(0, count($organization_ids), "?"));
 		$query =
 			"SELECT count(*) as matching_users ".
 			"FROM users ".
-			"WHERE id = %d ".
-			"AND org_id in (".str_repeat("%d,",count( $organization_ids )-1 ). "%d".")";
-		$query = call_user_func_array( "sprintf", array_merge((array)$query,(array)$user_id, $organization_ids));
-		$res = $this->db->query($query);
+			"WHERE id = ? ".
+			"AND org_id in ($placeholders)";
+		$res = $this->db->query($query, array_merge([$user_id], $organization_ids));
 		$result = $this->db->nextRow();
 		return $result['matching_users'] > 0;
 	}
@@ -258,13 +259,13 @@ function isMemberActive( $user_id ) {
 		if( count($organization_ids) == 0 ) {
 			return Array();
 		}
+		$placeholders = implode(",", array_fill(0, count($organization_ids), "?"));
 		$query =
 			"SELECT u.id ".
 			"FROM users u ".
 			"INNER JOIN `mes-portal`.User pu ON u.ww_number = pu.membershipNumber AND pu.membershipExpiration > NOW() ".
-			"WHERE u.org_id in (".str_repeat("%d,",count( $organization_ids )-1 ). "%d".")";
-		$query = call_user_func_array( "sprintf", array_merge((array)$query,$organization_ids));
-		$res = $this->db->query($query);
+			"WHERE u.org_id in ($placeholders)";
+		$res = $this->db->query($query, $organization_ids);
 		return $res->getAllRows();
 	}
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,11 @@
   Run "php tools/phpunit.phar" for all suites (see tests/README.md).
 
   Unit tests inject stub doubles for DAOs, so they need no database or settings.inc.
+
+  Integration tests (tests/Integration) run a real top-level page/include in an
+  isolated child PHP process via PageHarness, against an in-memory stub Database
+  (see tests/Integration/stub_includes); still fully offline, no real database.
+  See tests/README.md.
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
@@ -18,6 +23,9 @@
     <testsuites>
         <testsuite name="unit">
             <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/services/UserService.class.php
+++ b/services/UserService.class.php
@@ -22,15 +22,12 @@ class UserService {
 			"LEFT JOIN organizations o ON u.org_id = o.id " .
 			"LEFT JOIN portal_user_cache puc ON u.ww_number = puc.ww_number ";
 
-		$query .= $this->buildSearchClause($filter);
+		list($searchClause, $params) = $this->buildSearchClause($filter);
+		$query .= $searchClause;
+		$query .= "ORDER BY lastname, firstname LIMIT ?, 20";
+		$params[] = paginationOffset($filter["skip"]);
 
-		$query .= sprintf(
-			"ORDER BY lastname, firstname ".
-			"LIMIT %d, 20",
-			paginationOffset($filter["skip"])
-		);
-
-		$rs = $db->query($query);
+		$rs = $db->query($query, $params);
 		$rows = array();
 		while( $row = $rs->nextRow() ) {
 			$row['name'] = $this->buildName( $row['firstname'], $row['lastname'] );
@@ -47,33 +44,28 @@ class UserService {
 			"FROM users u " .
 			"LEFT JOIN organizations o ON u.org_id = o.id " .
 			"LEFT JOIN portal_user_cache puc ON u.ww_number = puc.ww_number ";
-		$countQuery .= $this->buildSearchClause($filter);
-		$db->query($countQuery);
+		list($searchClause, $params) = $this->buildSearchClause($filter);
+		$countQuery .= $searchClause;
+		$db->query($countQuery, $params);
 		$row = $db->nextRow();
 		return $row["usercount"];
 	}
 
 	function buildSearchClause( $filter = array() ) {
-		global $db;
 		if( "" == ($filter["search"] ?? "") ) {
-			return "WHERE puc.membership_expiration > NOW() ";
+			return [ "WHERE puc.membership_expiration > NOW() ", [] ];
 		}
 		// Use prefix LIKE (no leading wildcard) so indexes on ww_number,
 		// last_name, and first_name can be used by the query planner.
 		$searchClause =
 			"WHERE ( ".
-			"  u.ww_number LIKE '%s' ".
-			"  OR puc.last_name LIKE '%s' ".
-			"  OR puc.first_name LIKE '%s' ".
+			"  u.ww_number LIKE ? ".
+			"  OR puc.last_name LIKE ? ".
+			"  OR puc.first_name LIKE ? ".
 			") ".
 			"AND puc.membership_expiration > NOW() ";
-		$searchClause = sprintf(
-			$searchClause,
-			$db->escape($filter["search"]."%"),
-			$db->escape($filter["search"]."%"),
-			$db->escape($filter["search"]."%")
-		);
-		return $searchClause;
+		$like = $filter["search"] . "%";
+		return [ $searchClause, [ $like, $like, $like ] ];
 	}
 
 	function buildName ( $firstname, $lastname ) {

--- a/tests/Integration/PageHarness.php
+++ b/tests/Integration/PageHarness.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Runs a real top-level application page/include in an isolated child PHP
+ * process against a fully in-memory stub database, and reports back every
+ * SQL statement + bound params the page issued.
+ *
+ * Why a child process rather than an in-process include (as tests/Unit/
+ * does for classes): these are legacy procedural scripts that call
+ * header()/exit()/die() directly and read superglobals at the top level.
+ * Isolating each run in its own process means an exit() call only ends that
+ * child -- it can never take down the PHPUnit run -- while a shutdown
+ * function inside the child still reliably flushes captured queries even
+ * after a fatal error or an explicit exit().
+ *
+ * The real db.inc, header.inc, DAOFactory, and every DAO class run
+ * completely unmodified; only include/Database.class.php and
+ * include/settings.inc are shadowed (via -d include_path, which PHP checks
+ * before a bare include's calling-script directory) with an in-memory
+ * recorder. See stub_includes/include/Database.class.php.
+ *
+ * @see PageHarnessResult
+ */
+class PageHarness {
+
+    /**
+     * @param string $page Path to the target file, relative to the repo root (e.g. "footerbar.inc", "UserDisplay.php").
+     * @param array $get Populates $_GET before the page is included.
+     * @param array $post Populates $_POST before the page is included.
+     * @param array $session Populates $_SESSION before the page is included (after the harness's own session_start(), so it isn't reset).
+     * @param bool $ignoreLogin When true (default), sets a global $IGNORE_LOGIN so header.inc's login gate lets the request through without needing $_SESSION['user_id'] set (which would also trigger the separate, heavier session_setup.inc bootstrap). Set false only when specifically testing login-gate behavior.
+     * @param array $responses Canned row sets returned by successive $db->query() calls, in call order (FIFO) -- each entry is a list of associative-array rows for one query; a query beyond the queued responses gets an empty result.
+     * @return PageHarnessResult The captured queries, any header() calls, and the page's raw output/exit code.
+     * @throws RuntimeException if the child process cannot be started at all (a non-zero exit from the page itself is NOT an error -- that's normal for pages that redirect/die).
+     */
+    public static function run(
+        string $page,
+        array $get = [],
+        array $post = [],
+        array $session = [],
+        bool $ignoreLogin = true,
+        array $responses = []
+    ): PageHarnessResult {
+        $repoRoot = dirname( __DIR__, 2 );
+        $specFile = tempnam( sys_get_temp_dir(), 'aph_spec_' );
+        $outFile  = tempnam( sys_get_temp_dir(), 'aph_out_' );
+
+        file_put_contents( $specFile, json_encode( [
+            'page'        => $page,
+            'get'         => $get,
+            'post'        => $post,
+            'session'     => $session,
+            'ignoreLogin' => $ignoreLogin,
+            'responses'   => $responses,
+            'outFile'     => $outFile,
+        ] ) );
+
+        $driver = __DIR__ . DIRECTORY_SEPARATOR . 'driver.php';
+        $stubPath = __DIR__ . DIRECTORY_SEPARATOR . 'stub_includes';
+
+        $cmd = escapeshellarg( PHP_BINARY )
+            . ' -d include_path=' . escapeshellarg( $stubPath )
+            . ' -d error_reporting=' . escapeshellarg( (string)( E_ALL & ~E_DEPRECATED ) )
+            . ' -d display_errors=1'
+            . ' -d session.save_path=' . escapeshellarg( sys_get_temp_dir() )
+            . ' ' . escapeshellarg( $driver )
+            . ' ' . escapeshellarg( $specFile );
+
+        $descriptors = [ 1 => [ 'pipe', 'w' ], 2 => [ 'pipe', 'w' ] ];
+        $process = proc_open( $cmd, $descriptors, $pipes, $repoRoot );
+        if ( !is_resource( $process ) ) {
+            @unlink( $specFile );
+            @unlink( $outFile );
+            throw new RuntimeException( "PageHarness: failed to start child process for $page" );
+        }
+
+        $stdout = stream_get_contents( $pipes[1] );
+        $stderr = stream_get_contents( $pipes[2] );
+        fclose( $pipes[1] );
+        fclose( $pipes[2] );
+        $exitCode = proc_close( $process );
+
+        $captured = [];
+        if ( is_file( $outFile ) ) {
+            $captured = json_decode( file_get_contents( $outFile ), true ) ?? [];
+            @unlink( $outFile );
+        }
+        @unlink( $specFile );
+
+        return new PageHarnessResult(
+            $captured['queries'] ?? [],
+            $captured['headers'] ?? [],
+            $stdout,
+            $stderr,
+            $exitCode
+        );
+    }
+}
+
+/** Result of one PageHarness::run() call. */
+class PageHarnessResult {
+    /** @param array $queries Each entry: ['sql' => string, 'params' => array, 'db' => string]. */
+    public function __construct(
+        public readonly array $queries,
+        public readonly array $headers,
+        public readonly string $output,
+        public readonly string $stderr,
+        public readonly int $exitCode
+    ) {}
+
+    /** The SQL text of every captured query, in call order. */
+    public function sqlStatements(): array {
+        return array_column( $this->queries, 'sql' );
+    }
+
+    /** True if any captured query's SQL text contains $needle verbatim (e.g. to assert a raw value was NOT interpolated). */
+    public function anyQueryContains( string $needle ): bool {
+        foreach ( $this->sqlStatements() as $sql ) {
+            if ( str_contains( $sql, $needle ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** True if any captured query's params array contains $needle as one of its bound values. */
+    public function anyParamsContain( mixed $needle ): bool {
+        foreach ( $this->queries as $q ) {
+            if ( in_array( $needle, $q['params'], true ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/tests/Integration/driver.php
+++ b/tests/Integration/driver.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Standalone child-process driver for PageHarness::run().
+ *
+ * Reads a JSON spec (argv[1]) describing $_GET/$_POST/$_SESSION and canned
+ * DB row responses, then includes the target application page under those
+ * conditions with include_path shadowing the real Database class (see
+ * stub_includes/include/Database.class.php) -- every other included file
+ * (db.inc, header.inc, DAOFactory, every DAO class) is the real, unmodified
+ * application code. Captures every query issued to the stub $db and, via a
+ * shutdown function (so it still fires if the page calls exit()/die() or
+ * hits a fatal error), writes them to the spec's outFile as JSON.
+ *
+ * Never run directly -- always invoked by PageHarness::run() as a php -d
+ * include_path=... child process with cwd set to the repo root.
+ */
+
+$specFile = $argv[1] ?? null;
+if ( !$specFile || !is_file( $specFile ) ) {
+    fwrite( STDERR, "driver.php: missing or unreadable spec file\n" );
+    exit( 2 );
+}
+$spec = json_decode( file_get_contents( $specFile ), true );
+if ( !is_array( $spec ) ) {
+    fwrite( STDERR, "driver.php: spec file did not contain valid JSON\n" );
+    exit( 2 );
+}
+
+$GLOBALS['__captured_queries'] = [];
+$GLOBALS['__stub_responses'] = $spec['responses'] ?? [];
+
+register_shutdown_function( function () use ( $spec ) {
+    $out = [
+        'queries' => $GLOBALS['__captured_queries'] ?? [],
+        'headers' => function_exists( 'headers_list' ) ? headers_list() : [],
+    ];
+    file_put_contents( $spec['outFile'], json_encode( $out ) );
+} );
+
+$_GET = $spec['get'] ?? [];
+$_POST = $spec['post'] ?? [];
+
+// Start the session ourselves first so real db.inc's own
+// `if (session_status() === PHP_SESSION_NONE) { session_start(); }` guard
+// sees an already-active session and skips re-starting it -- otherwise
+// CLI's session_start() would reset $_SESSION back to empty.
+session_start();
+$_SESSION = $spec['session'] ?? [];
+
+if ( !empty( $spec['ignoreLogin'] ) ) {
+    // header.inc's login gate is `!isset($_SESSION['user_id']) && !isset($IGNORE_LOGIN)`;
+    // setting this lets tests exercise pages that sit behind that gate without
+    // needing $_SESSION['user_id'] set (which would also pull in the much
+    // heavier session_setup.inc bootstrap via db.inc).
+    $GLOBALS['IGNORE_LOGIN'] = 1;
+}
+
+include getcwd() . '/' . $spec['page'];

--- a/tests/Integration/stub_includes/include/Database.class.php
+++ b/tests/Integration/stub_includes/include/Database.class.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Stub replacement for include/Database.class.php, used ONLY by the
+ * Integration test harness (tests/Integration/PageHarness.php) via PHP's
+ * include_path resolution: a bare `include_once("include/Database.class.php")`
+ * checks include_path before the calling script's own directory, so pointing
+ * php's -d include_path at this file's parent directory makes every real
+ * application file (db.inc, DAOFactory, every DAO class) transparently talk
+ * to this in-memory recorder instead of a real MySQL connection.
+ *
+ * Every query passed to Database::query() is appended to a global capture
+ * list (read back by the harness after the driver process exits) instead of
+ * being executed, and returns a canned row set popped from a global queue the
+ * driver script populates from the test's fixture file. No network I/O, no
+ * real settings.inc, no real mysqli extension calls.
+ */
+
+class Database {
+    public $db_host;
+    public $db_user;
+    public $db_pass;
+    public $db_name;
+    public $dbh;
+    public $lastResult;
+
+    public function __construct( $host = null, $user = null, $pass = null, $name = null ) {
+        $this->db_host = $host;
+        $this->db_user = $user;
+        $this->db_pass = $pass;
+        $this->db_name = $name;
+        $this->dbh = null;
+    }
+
+    /** Mirrors the real class's escape() shape; no real mysqli handle exists, so this is a plain fallback. */
+    function escape( $source ) {
+        return addslashes( (string)$source );
+    }
+
+    /**
+     * Records the query instead of running it, and returns the next canned
+     * row set queued for this connection (FIFO), defaulting to an empty
+     * result when the test didn't queue one for this call.
+     */
+    function query( string $query, array $params = [] ) {
+        $GLOBALS['__captured_queries'][] = [ 'sql' => $query, 'params' => $params, 'db' => $this->db_name ];
+        $rows = array_shift( $GLOBALS['__stub_responses'] ) ?? [];
+        $this->lastResult = new StubResultSet( $rows );
+        return $this->lastResult;
+    }
+
+    function throwError() {
+        // Real class echoes debug info then exit()s on a query failure.
+        // The stub never fails a query, so this should never be reached.
+        exit( 1 );
+    }
+
+    function getAllRows() { return $this->lastResult->getAllRows(); }
+    function getFieldCount() { return $this->lastResult->getFieldCount(); }
+    function getFieldNames() { return $this->lastResult->getFieldNames(); }
+    function nextRow() { return $this->lastResult->nextRow(); }
+    function numRows() { return $this->lastResult->numRows(); }
+    function affectedRows() { return $this->lastResult->affectedRows(); }
+    function getField( $field ) { return $this->lastResult->getField( $field ); }
+    function getInsertId() { return 1; }
+}
+
+/** Mirrors include/ResultSet.class.php's public interface over a plain PHP array of assoc rows -- no mysqli_result involved. */
+class StubResultSet {
+    private $rows;
+    private $currentRow = 0;
+
+    public function __construct( array $rows ) {
+        $this->rows = array_values( $rows );
+    }
+
+    function getFieldCount() { return count( $this->rows ) > 0 ? count( $this->rows[0] ) : 0; }
+    function getFieldNames() { return count( $this->rows ) > 0 ? array_keys( $this->rows[0] ) : []; }
+
+    function nextRow() {
+        if ( isset( $this->rows[$this->currentRow] ) ) {
+            return $this->rows[$this->currentRow++];
+        }
+        return array();
+    }
+
+    function numRows() { return count( $this->rows ); }
+    function affectedRows() { return 0; }
+    function getField( $field ) { return $this->rows[$this->currentRow][$field] ?? null; }
+    function getAllRows() { return $this->rows; }
+}

--- a/tests/Integration/stub_includes/include/settings.inc
+++ b/tests/Integration/stub_includes/include/settings.inc
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Stub replacement for include/settings.inc, used only by the Integration
+ * test harness via include_path shadowing (see stub_includes/include/Database.class.php
+ * for the mechanism). Values are dummy placeholders -- the stub Database
+ * class never actually connects to them.
+ */
+
+$SETTINGS = array();
+
+$SETTINGS["APPROVALS_SERVER"]   = "stub";
+$SETTINGS["APPROVALS_USERNAME"] = "stub";
+$SETTINGS["APPROVALS_PASSWORD"] = "stub";
+$SETTINGS["APPROVALS_DATABASE"] = "approvals_2017";
+
+$SETTINGS["PORTAL_SERVER"]      = "stub";
+$SETTINGS["PORTAL_USERNAME"]    = "stub";
+$SETTINGS["PORTAL_PASSWORD"]    = "stub";
+$SETTINGS["PORTAL_DATABASE"]    = "mes-portal";
+
+$SETTINGS["OAUTH_CLIENT_ID"]     = "stub";
+$SETTINGS["OAUTH_CLIENT_SECRET"] = "stub";
+$SETTINGS["OAUTH_REDIRECT_URI"]  = "https://example.test/oauth_callback.php";
+$SETTINGS["OAUTH_TOKEN_URL"]     = "https://example.test/oauth/v2/token";
+$SETTINGS["OAUTH_API_URL"]       = "https://example.test/api/authorized/user.json";
+
+$SETTINGS["EARLY_ACCESS_ENABLED"] = false;
+$SETTINGS["GOOGLE_MAP_SYNC_ENABLED"] = false;

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,21 +17,58 @@ tools\get-phpunit.ps1       # Windows PowerShell
 ## Running
 
 ```bash
-php tools/phpunit.phar                    # all suites (config: phpunit.xml)
-php tools/phpunit.phar --testsuite unit   # unit suite only
+php tools/phpunit.phar                          # all suites (config: phpunit.xml)
+php tools/phpunit.phar --testsuite unit         # unit suite only
+php tools/phpunit.phar --testsuite integration  # integration suite only
 ```
 
 ## Layout
 
 - `tests/Unit/` — fast, offline unit tests. They inject **stub doubles** for DAOs, so
   they need no database and never load `include/settings.inc`. See `tests/bootstrap.php`.
+  `tests/Unit/support/` holds shared test doubles (not test files themselves) — e.g.
+  `RecordingDb.php`, a stand-in `Database` that records every `query($sql, $params)`
+  call, used by the SQL-injection regression tests to assert a query uses `?`
+  placeholders and that a tainted value only ever appears in `$params`.
+- `tests/Integration/` — runs a real top-level page/include (not just a class) in an
+  **isolated child PHP process** via `PageHarness::run()`, against an in-memory stub
+  `Database` (`tests/Integration/stub_includes/`) — still fully offline, no real
+  database. This exists because many of this app's page scripts are top-level
+  procedural code that calls `header()`/`exit()` directly and reads `$_GET`/`$_POST`/
+  `$_SESSION` — not unit-testable in-process the way a class is. Process isolation
+  means an `exit()` inside the target page only ends that child process; a shutdown
+  function in the child still flushes captured queries even after a fatal error.
+  The mechanism: only `include/Database.class.php` and `include/settings.inc` are
+  shadowed via PHP's `include_path` (checked before a bare include's calling-script
+  directory) — the real `db.inc`, `header.inc`, `DAOFactory`, and every DAO class run
+  completely unmodified against the stub connection.
+  **Known gap:** any page that transitively includes `application.inc` (which
+  `require_once`s Smarty from a hardcoded absolute Linux path,
+  `/usr/share/php/smarty3/SmartyBC.class.php`) cannot run under this harness on a
+  machine without that exact path — absolute-path includes bypass `include_path`
+  shadowing entirely. Those pages currently rely on the manual QA steps in their
+  PR's test plan instead.
 - `tests/test_final_approval.php` — a pre-existing self-contained **live-DB integration**
   script (its own assert harness). Run directly: `php tests/test_final_approval.php`.
-  It is not part of the `unit` suite because it requires DB connectivity and fixtures.
+  It is not part of either suite because it requires DB connectivity and fixtures.
 
 ## Writing a unit test
 
 `require_once` the app file under test at the top (the bootstrap has already `chdir`'d to
 the repo root), then inject anonymous-class stubs for its collaborators. Example pattern:
 `tests/Unit/GetLowSTTest.php` constructs `ApplicationService` with four stub DAOs and asserts
-the resolved storyteller id for each `vss_id` branch.
+the resolved storyteller id for each `vss_id` branch. For a query-building test, use
+`tests/Unit/support/RecordingDb.php` instead of an ad hoc stub — see
+`tests/Unit/UserInfoDAOSqliTest.php` for the pattern.
+
+## Writing an integration (page-script) test
+
+`require_once 'tests/Integration/PageHarness.php'`, then call
+`PageHarness::run($page, get: [...], post: [...], session: [...], responses: [...])`
+and assert on the returned `PageHarnessResult` (`->queries`, `->sqlStatements()`,
+`->anyQueryContains()`, `->anyParamsContain()`, `->exitCode`). `ignoreLogin` defaults to
+`true`, bypassing `header.inc`'s login gate without needing `$_SESSION['user_id']` set
+(which would also trigger the heavier `session_setup.inc` bootstrap) — pass `false` only
+when specifically testing login-gate behavior. `responses` supplies one row-array per
+expected `$db->query()` call, in call order; a call beyond the queued responses gets an
+empty result. See `tests/Integration/FooterbarSqliTest.php` for the pattern.

--- a/tests/Unit/ApplicationDAOSqliTest.php
+++ b/tests/Unit/ApplicationDAOSqliTest.php
@@ -1,0 +1,44 @@
+<?php
+require_once 'classes/ApplicationDAO.php';
+require_once 'classes/Filter.php';
+require_once 'tests/Unit/support/RecordingDb.php';
+
+/**
+ * Regression test confirming ApplicationDAO::readApplicationIDsByFilters()
+ * casts each $admin_org_venue_list key to (int) before splicing it into a
+ * dynamic temporary-table name and join alias -- identifiers can't be bound
+ * as query parameters, so this is the one spot in the method that needs an
+ * explicit cast rather than a placeholder. $admin_org_venue_list is normally
+ * server-computed from the session user's own permissions, not raw request
+ * input, but the cast is cheap insurance against it ever carrying anything
+ * else.
+ *
+ * @see ApplicationDAO::readApplicationIDsByFilters()
+ */
+final class ApplicationDAOSqliTest extends \PHPUnit\Framework\TestCase {
+
+	public function testVenueIdKeyIsCastToIntBeforeUseAsAnIdentifier(): void {
+		$db = new RecordingDb();
+		$dao = new ApplicationDAO( $db );
+		$filter = new Filter();
+		$_SESSION['super_user'] = 0;
+
+		// A non-numeric string key: PHP keeps this as a string array key (only
+		// canonical integer-looking strings get auto-cast), so it reaches the
+		// method exactly as an attacker-influenced value would.
+		$maliciousVenueId = "5' OR '1'='1";
+		$adminOrgVenueList = [ $maliciousVenueId => [ 1, 2, 3 ] ];
+
+		$dao->readApplicationIDsByFilters( $filter, 1, $adminOrgVenueList, [], '', [] );
+
+		$tempTableQueries = array_filter(
+			$db->sqlStatements(),
+			fn( $sql ) => str_starts_with( $sql, 'create temporary table user_orgids' )
+		);
+		$this->assertNotEmpty( $tempTableQueries, 'expected a CREATE TEMPORARY TABLE query to have been issued' );
+		foreach ( $tempTableQueries as $sql ) {
+			$this->assertStringNotContainsString( "'", $sql, 'temp table name must not carry the raw key through' );
+			$this->assertMatchesRegularExpression( '/user_orgids\d+\s/', $sql, 'venue id must render as a plain integer' );
+		}
+	}
+}

--- a/tests/Unit/UserInfoDAOSqliTest.php
+++ b/tests/Unit/UserInfoDAOSqliTest.php
@@ -1,0 +1,131 @@
+<?php
+require_once 'classes/UserInfoDAO.php';
+require_once 'tests/Unit/support/RecordingDb.php';
+
+/**
+ * Regression tests confirming UserInfoDAO's query-building methods bind
+ * caller-supplied values as parameters rather than splicing them into the
+ * SQL text. Before this fix these methods used sprintf('%d'/'%s', ...) --
+ * safe in practice for the %d cases and escaped for the %s cases, but not
+ * this codebase's parameterized-query standard, and one missed escape() call
+ * away from a real injection. Each test uses a value containing a single
+ * quote to prove it cannot break out of the query if it ever reached the SQL
+ * string directly.
+ *
+ * @see UserInfoDAO
+ */
+final class UserInfoDAOSqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "1' OR '1'='1";
+
+	public function testUpdateLastLoginDateBindsId(): void {
+		$db = new RecordingDb();
+		$dao = new UserInfoDAO( $db );
+
+		$dao->updateLastLoginDate( self::TAINTED );
+
+		$this->assertSame( 'UPDATE users SET last_login_date = now() WHERE id=?', $db->queries[0]['sql'] );
+		$this->assertSame( [ self::TAINTED ], $db->queries[0]['params'] );
+	}
+
+	public function testReadApprovalsDBInfoBindsId(): void {
+		$db = new RecordingDb( [ [] ] );
+		$dao = new UserInfoDAO( $db );
+
+		$dao->readApprovalsDBInfo( self::TAINTED );
+
+		$this->assertStringNotContainsString( self::TAINTED, $db->queries[0]['sql'] );
+		$this->assertStringContainsString( 'id=?', $db->queries[0]['sql'] );
+		$this->assertSame( [ self::TAINTED ], $db->queries[0]['params'] );
+	}
+
+	public function testReadPortalUserInfoBindsMemberNumber(): void {
+		$portalDb = new RecordingDb( [ [] ] );
+		$dao = new UserInfoDAO( new RecordingDb(), $portalDb );
+
+		$dao->readPortalUserInfo( self::TAINTED );
+
+		$this->assertStringNotContainsString( self::TAINTED, $portalDb->queries[0]['sql'] );
+		$this->assertStringContainsString( 'membershipNumber = ?', $portalDb->queries[0]['sql'] );
+		$this->assertSame( [ self::TAINTED ], $portalDb->queries[0]['params'] );
+	}
+
+	public function testIsMemberActiveByWwNumberBindsWwNumber(): void {
+		$portalDb = new RecordingDb( [ [] ] );
+		$dao = new UserInfoDAO( new RecordingDb(), $portalDb );
+
+		$dao->isMemberActiveByWwNumber( self::TAINTED );
+
+		$this->assertStringNotContainsString( self::TAINTED, $portalDb->queries[0]['sql'] );
+		$this->assertStringContainsString( 'membershipNumber = ?', $portalDb->queries[0]['sql'] );
+		$this->assertSame( [ self::TAINTED ], $portalDb->queries[0]['params'] );
+	}
+
+	public function testGetVSTPositionsBindsUserId(): void {
+		$db = new RecordingDb( [ [] ] );
+		$dao = new UserInfoDAO( $db );
+
+		$dao->getVSTPositions( self::TAINTED );
+
+		$this->assertStringNotContainsString( self::TAINTED, $db->queries[0]['sql'] );
+		$this->assertStringContainsString( 'storyteller_id=?', $db->queries[0]['sql'] );
+		$this->assertSame( [ self::TAINTED ], $db->queries[0]['params'] );
+	}
+
+	public function testGetOrgSTPositionsBindsUserId(): void {
+		$db = new RecordingDb( [ [] ] );
+		$dao = new UserInfoDAO( $db );
+
+		$dao->getOrgSTPositions( self::TAINTED );
+
+		$this->assertStringNotContainsString( self::TAINTED, $db->queries[0]['sql'] );
+		$this->assertStringContainsString( 's.user_id=?', $db->queries[0]['sql'] );
+		$this->assertSame( [ self::TAINTED ], $db->queries[0]['params'] );
+	}
+
+	public function testReadIdsByCamNumberBindsCamNumber(): void {
+		$db = new RecordingDb( [ [] ] );
+		$dao = new UserInfoDAO( $db );
+
+		$dao->readIdsByCamNumber( self::TAINTED );
+
+		$this->assertStringNotContainsString( self::TAINTED, $db->queries[0]['sql'] );
+		$this->assertStringContainsString( 'ww_number=?', $db->queries[0]['sql'] );
+		$this->assertSame( [ self::TAINTED ], $db->queries[0]['params'] );
+	}
+
+	public function testIsUserUnderOrganizationBindsEveryId(): void {
+		$db = new RecordingDb( [ [ [ 'matching_users' => 0 ] ] ] );
+		$dao = new UserInfoDAO( $db );
+
+		$dao->isUserUnderOrganization( self::TAINTED, [ 5, self::TAINTED, 9 ] );
+
+		$sql = $db->queries[0]['sql'];
+		$this->assertStringNotContainsString( self::TAINTED, $sql );
+		// One placeholder for the user id, three more for the org id list.
+		$this->assertSame( 4, substr_count( $sql, '?' ) );
+		$this->assertSame( [ self::TAINTED, 5, self::TAINTED, 9 ], $db->queries[0]['params'] );
+	}
+
+	public function testReadIdsByOrganizationsBindsEveryId(): void {
+		$db = new RecordingDb( [ [] ] );
+		$dao = new UserInfoDAO( $db );
+
+		$dao->readIdsByOrganizations( [ 5, self::TAINTED ] );
+
+		$sql = $db->queries[0]['sql'];
+		$this->assertStringNotContainsString( self::TAINTED, $sql );
+		$this->assertSame( 2, substr_count( $sql, '?' ) );
+		$this->assertSame( [ 5, self::TAINTED ], $db->queries[0]['params'] );
+	}
+
+	/** With no organization ids, both list methods must short-circuit without querying at all. */
+	public function testEmptyOrganizationListsSkipTheQueryEntirely(): void {
+		$db = new RecordingDb();
+		$dao = new UserInfoDAO( $db );
+
+		$this->assertFalse( $dao->isUserUnderOrganization( 1, [] ) );
+		$this->assertSame( [], $dao->readIdsByOrganizations( [] ) );
+		$this->assertCount( 0, $db->queries );
+	}
+}

--- a/tests/Unit/UserServiceSqliTest.php
+++ b/tests/Unit/UserServiceSqliTest.php
@@ -1,0 +1,67 @@
+<?php
+require_once 'services/UserService.class.php';
+require_once 'tests/Unit/support/RecordingDb.php';
+
+/**
+ * Regression tests confirming UserService's user-search query building binds
+ * the search term as a parameter rather than splicing it into the SQL text.
+ * Before this fix, buildSearchClause() built its LIKE clauses via
+ * sprintf('%s', ...) wrapped in $db->escape() -- safe in practice, but not
+ * this codebase's parameterized-query standard, and it returned a
+ * pre-escaped string rather than participating in the caller's params array.
+ *
+ * @see UserService::buildSearchClause()
+ * @see UserService::fetchMatchingUsers()
+ * @see UserService::countMatchingUsers()
+ */
+final class UserServiceSqliTest extends \PHPUnit\Framework\TestCase {
+
+	private const TAINTED = "o'brien";
+
+	protected function setUp(): void {
+		unset( $GLOBALS['db'] );
+	}
+
+	public function testFetchMatchingUsersBindsSearchTerm(): void {
+		$GLOBALS['db'] = $db = new RecordingDb( [ [] ] );
+		$service = new UserService();
+
+		$service->fetchMatchingUsers( [ 'search' => self::TAINTED, 'skip' => 0 ] );
+
+		$sql = $db->queries[0]['sql'];
+		$this->assertStringNotContainsString( self::TAINTED, $sql );
+		$this->assertStringContainsString( 'LIKE ?', $sql );
+		$this->assertContains( self::TAINTED . '%', $db->queries[0]['params'] );
+	}
+
+	public function testCountMatchingUsersBindsSearchTerm(): void {
+		$GLOBALS['db'] = $db = new RecordingDb( [ [ [ 'usercount' => 0 ] ] ] );
+		$service = new UserService();
+
+		$service->countMatchingUsers( [ 'search' => self::TAINTED ] );
+
+		$sql = $db->queries[0]['sql'];
+		$this->assertStringNotContainsString( self::TAINTED, $sql );
+		$this->assertStringContainsString( 'LIKE ?', $sql );
+		$this->assertContains( self::TAINTED . '%', $db->queries[0]['params'] );
+	}
+
+	public function testBuildSearchClauseReturnsPlaceholdersAndParams(): void {
+		$service = new UserService();
+
+		[ $clause, $params ] = $service->buildSearchClause( [ 'search' => self::TAINTED ] );
+
+		$this->assertStringNotContainsString( self::TAINTED, $clause );
+		$this->assertStringContainsString( 'LIKE ?', $clause );
+		$this->assertSame( [ self::TAINTED . '%', self::TAINTED . '%', self::TAINTED . '%' ], $params );
+	}
+
+	public function testBuildSearchClauseWithNoSearchTermReturnsNoParams(): void {
+		$service = new UserService();
+
+		[ $clause, $params ] = $service->buildSearchClause( [] );
+
+		$this->assertSame( [], $params );
+		$this->assertStringContainsString( 'membership_expiration', $clause );
+	}
+}

--- a/tests/Unit/support/RecordingDb.php
+++ b/tests/Unit/support/RecordingDb.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Minimal stand-in for the real Database class, shared by the SQL-injection
+ * regression tests: records every SQL string and bound params array passed
+ * to query(), and returns a canned row set (or none) so a test can assert
+ * the query text uses ?-placeholders and that a tainted value only ever
+ * appears in $params, never spliced into $sql.
+ *
+ * @see Database in include/Database.class.php, the real class this doubles for.
+ */
+class RecordingDb {
+	/** @var array<int, array{sql: string, params: array}> Every query() call, in order. */
+	public array $queries = [];
+
+	private array $responses;
+	private array $lastRows = [];
+	private int $cursor = 0;
+
+	/** @param array $responses One row-array per expected query() call, in call order (FIFO). A call beyond the queued responses gets no rows. */
+	public function __construct( array $responses = [] ) {
+		$this->responses = $responses;
+	}
+
+	public function query( string $sql, array $params = [] ) {
+		$this->queries[] = [ 'sql' => $sql, 'params' => $params ];
+		$this->lastRows = array_shift( $this->responses ) ?? [];
+		$this->cursor = 0;
+		return $this;
+	}
+
+	public function escape( $value ) {
+		return addslashes( (string)$value );
+	}
+
+	public function nextRow() {
+		if ( isset( $this->lastRows[ $this->cursor ] ) ) {
+			return $this->lastRows[ $this->cursor++ ];
+		}
+		return array();
+	}
+
+	public function numRows(): int {
+		return count( $this->lastRows );
+	}
+
+	public function getAllRows(): array {
+		return $this->lastRows;
+	}
+
+	/** The SQL text of every query() call, in order. */
+	public function sqlStatements(): array {
+		return array_column( $this->queries, 'sql' );
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #47, Fixes #48, Fixes #49, Fixes #50, Fixes #51 — PR 3 of 3 in the SQL injection remediation plan (see #52 and #53 for PRs 1 and 2, the exploitable findings).

None of these were exploitable today (values were either `%d`-coerced or wrapped in `$db->escape()`/`mysqli_escape_string`), but they're the older pattern this codebase is moving away from — one missed `escape()` call in future changes and any of these becomes another `footerbar.inc`-style bug.

- **`classes/UserInfoDAO.php`** (#47): 9 methods converted (`updateLastLoginDate`, `readApprovalsDBInfo`, `readPortalUserInfo`, `isMemberActiveByWwNumber`, `getVSTPositions`, `getOrgSTPositions`, `readIdsByCamNumber`, `isUserUnderOrganization`, `readIdsByOrganizations`).
- **`classes/ApplicationDAO.php`** (#48): `readApplicationIDsByFilters` now casts `$venue_id` to `(int)` before it's used in a dynamic temp-table name/join alias.
- **`services/UserService.class.php`** (#49): `buildSearchClause()` now returns `[clauseText, params]` instead of a pre-escaped string; both callers (`fetchMatchingUsers`, `countMatchingUsers` — its only callers anywhere in the codebase) updated accordingly.
- **`AppDetailsTopSection.php`** (#50): 4 `organizations` lookup queries converted.
- **`ModifyCategoryList3.php`** (#51): 2 queries converted.

## Test plan
- [x] `php -l` on all 5 files — no syntax errors
- [ ] Log in and confirm login/session setup still works (exercises `readApprovalsDBInfo`, `updateLastLoginDate`)
- [ ] Confirm the user-popup tooltips still show correct positions (exercises `getVSTPositions`/`getOrgSTPositions`)
- [ ] Search/list users on `UserList.php` with and without a search term (exercises `UserService::buildSearchClause`/`fetchMatchingUsers`/`countMatchingUsers`)
- [ ] Open an application's detail page and confirm the CST/DST/RST/NST storyteller contacts still resolve correctly (exercises `AppDetailsTopSection.php`)
- [ ] Edit an existing category (exercises `ModifyCategoryList3.php`)
- [ ] Tail `/var/log/nginx/legacy_error.log` after deploy for any new SQL-related fatals