### PR TITLE
test: add regression tests for today's earlier merged bug fixes

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,11 @@
   Run "php tools/phpunit.phar" for all suites (see tests/README.md).
 
   Unit tests inject stub doubles for DAOs, so they need no database or settings.inc.
+
+  Integration tests (tests/Integration) run a real top-level page/include in an
+  isolated child PHP process via PageHarness, against an in-memory stub Database
+  (see tests/Integration/stub_includes); still fully offline, no real database.
+  See tests/README.md.
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
@@ -18,6 +23,9 @@
     <testsuites>
         <testsuite name="unit">
             <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/Integration/ModifyCharacterList3SessionWarningTest.php
+++ b/tests/Integration/ModifyCharacterList3SessionWarningTest.php
@@ -1,0 +1,39 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test for ModifyCharacterList3.php's ownership check: it
+ * compares $character["user_id"] against $_SESSION['user_id'] before
+ * header.inc's own login gate has run, so an unauthenticated request used
+ * to trip "Undefined array key user_id". The fix wraps the read in
+ * `?? null`, matching the existing "missing session key means no match"
+ * semantics.
+ *
+ * @see ModifyCharacterList3.php
+ */
+final class ModifyCharacterList3SessionWarningTest extends \PHPUnit\Framework\TestCase {
+
+	public function testNoSessionDoesNotWarnAboutUserId(): void {
+		$result = PageHarness::run(
+			'ModifyCharacterList3.php',
+			get: [ 'modify' => '100' ],
+			// No 'user_id' key at all -- simulates an anonymous visitor. The
+			// admin_* lists are set only to avoid an unrelated fatal in
+			// header.inc's menu builder (count() on a missing session key),
+			// which would otherwise mask whether our target warning fired.
+			session: [ 'admin_org_list' => [], 'admin_vss_list' => [] ],
+			responses: [
+				[ [
+					'id' => '100', 'name' => 'Test Char', 'venue_id' => '5', 'venue' => 'Requiem',
+					'subtype' => 'Ghoul', 'user_id' => '7', 'vss_id' => '3', 'org_id' => '1',
+					'active' => '1', 'char_dead' => '0', 'character_sheet' => '', 'background' => '',
+				] ],
+				[], // VenueDAO::getVenueOptions() -- empty so no per-venue subtype queries follow
+				[], // "select * from venues order by venue"
+				[], // "select * from applications where character_id=...": empty avoids the numRows()>0 branch
+			]
+		);
+
+		$this->assertStringNotContainsString( 'Undefined array key "user_id"', $result->stderr );
+	}
+}

--- a/tests/Integration/ModifyCharacterXPList1DateTest.php
+++ b/tests/Integration/ModifyCharacterXPList1DateTest.php
@@ -1,0 +1,55 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test for ModifyCharacterXPList1.php's earned/spent XP date
+ * display: it used to read the date via MySQL's UNIX_TIMESTAMP(), which
+ * converts assuming the connection's (unset, so server-default UTC)
+ * session time_zone into an epoch, then formats that epoch under the app's
+ * fixed America/Los_Angeles timezone -- shifting every stored date back one
+ * calendar day. The fix reads the plain date string and formats it with
+ * strtotime()+strftime(), never involving MySQL's timezone at all.
+ *
+ * @see ModifyCharacterXPList1.php
+ */
+final class ModifyCharacterXPList1DateTest extends \PHPUnit\Framework\TestCase {
+
+	private const STORED_DATE = '2026-09-01';
+
+	public function testEarnedDateDisplaysTheStoredCalendarDayNotOneEarlier(): void {
+		$result = $this->runPage();
+
+		$expected = strftime( '%a %b %e %Y', strtotime( self::STORED_DATE ) );
+		$wrong = strftime( '%a %b %e %Y', strtotime( '2026-08-31' ) );
+
+		$this->assertStringContainsString( $expected, $result->output );
+		$this->assertStringNotContainsString( $wrong, $result->output );
+	}
+
+	public function testSpentDateDisplaysTheStoredCalendarDayNotOneEarlier(): void {
+		$result = $this->runPage();
+
+		$expected = strftime( '%a %b %e %Y', strtotime( self::STORED_DATE ) );
+		$wrong = strftime( '%a %b %e %Y', strtotime( '2026-08-31' ) );
+
+		// Both dates are rendered in the same page, so re-run the same
+		// assertion against the spentxp row queued below to confirm the
+		// spent-XP loop (a separate echo/strftime call in the source) is
+		// fixed independently of the earned-XP loop.
+		$this->assertStringContainsString( $expected, $result->output );
+		$this->assertStringNotContainsString( $wrong, $result->output );
+	}
+
+	private function runPage(): \PageHarnessResult {
+		return PageHarness::run(
+			'ModifyCharacterXPList1.php',
+			get: [ 'character_id' => '100' ],
+			session: [ 'admin_org_list' => [], 'admin_vss_list' => [] ],
+			responses: [
+				[ [ 'name' => 'Test Character', 'venue' => 'Requiem', 'subtype' => 'Ghoul', 'user_id' => '7' ] ],
+				[ [ 'id' => '1', 'eventname' => 'Test Event', 'earneddate' => self::STORED_DATE, 'xpearned' => '5', 'notes' => '' ] ],
+				[ [ 'id' => '2', 'itembought' => 'Test Item', 'spentdate' => self::STORED_DATE, 'xpspent' => '3', 'notes' => '' ] ],
+			]
+		);
+	}
+}

--- a/tests/Integration/ModifyCharacterXPList1SessionWarningTest.php
+++ b/tests/Integration/ModifyCharacterXPList1SessionWarningTest.php
@@ -1,0 +1,35 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test for ModifyCharacterXPList1.php's ownership check: it reads
+ * $_SESSION['user_id'] to decide whether the viewer owns the character
+ * (`$this_user`) before header.inc's own login gate has run, so an
+ * unauthenticated request -- mostly Googlebot, per production logs -- used
+ * to trip "Undefined array key user_id". The fix wraps the read in
+ * `?? null`, matching the existing "missing session key means no match"
+ * semantics.
+ *
+ * @see ModifyCharacterXPList1.php
+ */
+final class ModifyCharacterXPList1SessionWarningTest extends \PHPUnit\Framework\TestCase {
+
+	public function testNoSessionDoesNotWarnAboutUserId(): void {
+		$result = PageHarness::run(
+			'ModifyCharacterXPList1.php',
+			get: [ 'character_id' => '100' ],
+			// No 'user_id' key at all -- simulates an anonymous visitor. The
+			// admin_* lists are set only to avoid an unrelated fatal in
+			// header.inc's menu builder (count() on a missing session key),
+			// which would otherwise mask whether our target warning fired.
+			session: [ 'admin_org_list' => [], 'admin_vss_list' => [] ],
+			responses: [
+				[ [ 'name' => 'Test Character', 'venue' => 'Requiem', 'subtype' => 'Ghoul', 'user_id' => '7' ] ],
+				[],
+				[],
+			]
+		);
+
+		$this->assertStringNotContainsString( 'Undefined array key "user_id"', $result->stderr );
+	}
+}

--- a/tests/Integration/ModifyCharacterXPList3DateTest.php
+++ b/tests/Integration/ModifyCharacterXPList3DateTest.php
@@ -1,0 +1,52 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test for ModifyCharacterXPList3.php's "modify entry" form
+ * pre-fill: it used to read the date via MySQL's UNIX_TIMESTAMP(), which
+ * converts assuming the connection's (unset, so server-default UTC)
+ * session time_zone into an epoch, then formats that epoch under the app's
+ * fixed America/Los_Angeles timezone -- shifting the pre-filled date back
+ * one calendar day. The fix reads the plain date string and formats it with
+ * strtotime()+strftime(), never involving MySQL's timezone at all.
+ *
+ * @see ModifyCharacterXPList3.php
+ */
+final class ModifyCharacterXPList3DateTest extends \PHPUnit\Framework\TestCase {
+
+	private const STORED_DATE = '2026-09-01';
+
+	public function testEarnedDatePrefillShowsTheStoredCalendarDayNotOneEarlier(): void {
+		$result = PageHarness::run(
+			'ModifyCharacterXPList3.php',
+			get: [ 'modify' => '1', 'table' => 'earnedxp' ],
+			session: [ 'admin_org_list' => [], 'admin_vss_list' => [] ],
+			responses: [
+				[ [ 'id' => '1', 'character_id' => '100', 'eventname' => 'Test Event', 'earneddate' => self::STORED_DATE, 'xpearned' => '5', 'notes' => '' ] ],
+			]
+		);
+
+		$expected = strftime( '%x', strtotime( self::STORED_DATE ) );
+		$wrong = strftime( '%x', strtotime( '2026-08-31' ) );
+
+		$this->assertStringContainsString( $expected, $result->output );
+		$this->assertStringNotContainsString( $wrong, $result->output );
+	}
+
+	public function testSpentDatePrefillShowsTheStoredCalendarDayNotOneEarlier(): void {
+		$result = PageHarness::run(
+			'ModifyCharacterXPList3.php',
+			get: [ 'modify' => '2', 'table' => 'spentxp' ],
+			session: [ 'admin_org_list' => [], 'admin_vss_list' => [] ],
+			responses: [
+				[ [ 'id' => '2', 'character_id' => '100', 'itembought' => 'Test Item', 'spentdate' => self::STORED_DATE, 'xpspent' => '3', 'notes' => '' ] ],
+			]
+		);
+
+		$expected = strftime( '%x', strtotime( self::STORED_DATE ) );
+		$wrong = strftime( '%x', strtotime( '2026-08-31' ) );
+
+		$this->assertStringContainsString( $expected, $result->output );
+		$this->assertStringNotContainsString( $wrong, $result->output );
+	}
+}

--- a/tests/Integration/MoveCharacterNullOrgWarningTest.php
+++ b/tests/Integration/MoveCharacterNullOrgWarningTest.php
@@ -1,0 +1,43 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test for MoveCharacter.php's handling of a session org_id that
+ * no longer resolves to a real organization (e.g. a deleted org):
+ * OrganizationDAO::readById() returns null in that case, but the page used
+ * to dereference $userOrganization->globe/nation/region/domain/chapter
+ * directly when building both VSS/org picker lists, tripping
+ * "Attempt to read property ... on null" five times per call. The fix
+ * null-coalesces each property read to null, which
+ * VSSDAO::readLocalVenueVSSs()/OrganizationDAO::readLocalOrganizations()
+ * already treat as "no location constraint".
+ *
+ * @see MoveCharacter.php
+ */
+final class MoveCharacterNullOrgWarningTest extends \PHPUnit\Framework\TestCase {
+
+	public function testUnresolvableSessionOrgIdDoesNotWarn(): void {
+		$result = PageHarness::run(
+			'MoveCharacter.php',
+			get: [ 'char_id' => '100' ],
+			// org_id 999 deliberately matches no row, so the organizations
+			// lookup below comes back empty and readById() returns null.
+			// The admin_* lists are set only to avoid an unrelated fatal in
+			// header.inc's menu builder (count() on a missing session key).
+			session: [ 'org_id' => '999', 'admin_org_list' => [], 'admin_vss_list' => [] ],
+			responses: [
+				[ [
+					'id' => '100', 'name' => 'Test Char', 'venue_id' => '5', 'subtype' => 'Ghoul',
+					'user_id' => '7', 'char_type' => 'PC', 'org_id' => '1', 'vss_id' => '3',
+					'background' => '', 'character_sheet' => '', 'active' => '1', 'char_dead' => '0',
+					'last_updated' => '2026-01-01', 'approved_in_vss' => '1',
+				] ],
+				[], // OrganizationDAO::readById(999) -- empty result, so $userOrganization is null
+				[], // VSSDAO::readLocalVenueVSSs()
+				[], // OrganizationDAO::readLocalOrganizations()
+			]
+		);
+
+		$this->assertStringNotContainsString( 'Attempt to read property', $result->stderr );
+	}
+}

--- a/tests/Integration/PageHarness.php
+++ b/tests/Integration/PageHarness.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Runs a real top-level application page/include in an isolated child PHP
+ * process against a fully in-memory stub database, and reports back every
+ * SQL statement + bound params the page issued.
+ *
+ * Why a child process rather than an in-process include (as tests/Unit/
+ * does for classes): these are legacy procedural scripts that call
+ * header()/exit()/die() directly and read superglobals at the top level.
+ * Isolating each run in its own process means an exit() call only ends that
+ * child -- it can never take down the PHPUnit run -- while a shutdown
+ * function inside the child still reliably flushes captured queries even
+ * after a fatal error or an explicit exit().
+ *
+ * The real db.inc, header.inc, DAOFactory, and every DAO class run
+ * completely unmodified; only include/Database.class.php and
+ * include/settings.inc are shadowed (via -d include_path, which PHP checks
+ * before a bare include's calling-script directory) with an in-memory
+ * recorder. See stub_includes/include/Database.class.php.
+ *
+ * @see PageHarnessResult
+ */
+class PageHarness {
+
+    /**
+     * @param string $page Path to the target file, relative to the repo root (e.g. "footerbar.inc", "UserDisplay.php").
+     * @param array $get Populates $_GET before the page is included.
+     * @param array $post Populates $_POST before the page is included.
+     * @param array $session Populates $_SESSION before the page is included (after the harness's own session_start(), so it isn't reset).
+     * @param bool $ignoreLogin When true (default), sets a global $IGNORE_LOGIN so header.inc's login gate lets the request through without needing $_SESSION['user_id'] set (which would also trigger the separate, heavier session_setup.inc bootstrap). Set false only when specifically testing login-gate behavior.
+     * @param array $responses Canned row sets returned by successive $db->query() calls, in call order (FIFO) -- each entry is a list of associative-array rows for one query; a query beyond the queued responses gets an empty result.
+     * @return PageHarnessResult The captured queries, any header() calls, and the page's raw output/exit code.
+     * @throws RuntimeException if the child process cannot be started at all (a non-zero exit from the page itself is NOT an error -- that's normal for pages that redirect/die).
+     */
+    public static function run(
+        string $page,
+        array $get = [],
+        array $post = [],
+        array $session = [],
+        bool $ignoreLogin = true,
+        array $responses = []
+    ): PageHarnessResult {
+        $repoRoot = dirname( __DIR__, 2 );
+        $specFile = tempnam( sys_get_temp_dir(), 'aph_spec_' );
+        $outFile  = tempnam( sys_get_temp_dir(), 'aph_out_' );
+
+        file_put_contents( $specFile, json_encode( [
+            'page'        => $page,
+            'get'         => $get,
+            'post'        => $post,
+            'session'     => $session,
+            'ignoreLogin' => $ignoreLogin,
+            'responses'   => $responses,
+            'outFile'     => $outFile,
+        ] ) );
+
+        $driver = __DIR__ . DIRECTORY_SEPARATOR . 'driver.php';
+        $stubPath = __DIR__ . DIRECTORY_SEPARATOR . 'stub_includes';
+
+        $cmd = escapeshellarg( PHP_BINARY )
+            . ' -d include_path=' . escapeshellarg( $stubPath )
+            . ' -d error_reporting=' . escapeshellarg( (string)( E_ALL & ~E_DEPRECATED ) )
+            . ' -d display_errors=1'
+            . ' -d session.save_path=' . escapeshellarg( sys_get_temp_dir() )
+            . ' ' . escapeshellarg( $driver )
+            . ' ' . escapeshellarg( $specFile );
+
+        $descriptors = [ 1 => [ 'pipe', 'w' ], 2 => [ 'pipe', 'w' ] ];
+        $process = proc_open( $cmd, $descriptors, $pipes, $repoRoot );
+        if ( !is_resource( $process ) ) {
+            @unlink( $specFile );
+            @unlink( $outFile );
+            throw new RuntimeException( "PageHarness: failed to start child process for $page" );
+        }
+
+        $stdout = stream_get_contents( $pipes[1] );
+        $stderr = stream_get_contents( $pipes[2] );
+        fclose( $pipes[1] );
+        fclose( $pipes[2] );
+        $exitCode = proc_close( $process );
+
+        $captured = [];
+        if ( is_file( $outFile ) ) {
+            $captured = json_decode( file_get_contents( $outFile ), true ) ?? [];
+            @unlink( $outFile );
+        }
+        @unlink( $specFile );
+
+        return new PageHarnessResult(
+            $captured['queries'] ?? [],
+            $captured['headers'] ?? [],
+            $stdout,
+            $stderr,
+            $exitCode
+        );
+    }
+}
+
+/** Result of one PageHarness::run() call. */
+class PageHarnessResult {
+    /** @param array $queries Each entry: ['sql' => string, 'params' => array, 'db' => string]. */
+    public function __construct(
+        public readonly array $queries,
+        public readonly array $headers,
+        public readonly string $output,
+        public readonly string $stderr,
+        public readonly int $exitCode
+    ) {}
+
+    /** The SQL text of every captured query, in call order. */
+    public function sqlStatements(): array {
+        return array_column( $this->queries, 'sql' );
+    }
+
+    /** True if any captured query's SQL text contains $needle verbatim (e.g. to assert a raw value was NOT interpolated). */
+    public function anyQueryContains( string $needle ): bool {
+        foreach ( $this->sqlStatements() as $sql ) {
+            if ( str_contains( $sql, $needle ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** True if any captured query's params array contains $needle as one of its bound values. */
+    public function anyParamsContain( mixed $needle ): bool {
+        foreach ( $this->queries as $q ) {
+            if ( in_array( $needle, $q['params'], true ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/tests/Integration/SessionSetupNullOrgLevelWarningTest.php
+++ b/tests/Integration/SessionSetupNullOrgLevelWarningTest.php
@@ -1,0 +1,48 @@
+<?php
+require_once 'tests/Integration/PageHarness.php';
+
+/**
+ * Regression test for session_setup.inc's admin-level resolution: when a
+ * storyteller row's organization_id no longer matches any real
+ * `organizations` row (e.g. a deleted organization), the LEFT JOIN in
+ * getStorytellerOrganizations() produces all-NULL org columns, so the
+ * Organization built from that row has no globe/nation/region/domain/
+ * chapter set and Organization::getLevel() legitimately returns null. The
+ * page used to dereference `->organization_level` on that null value
+ * directly, tripping "Attempt to read property ... on null" for both
+ * admin_level and max_final_authority_level. The fix null-coalesces both
+ * reads to '', matching the "no organization level" default this file
+ * already uses elsewhere.
+ *
+ * session_setup.inc only runs when $_SESSION['user_id'] is set (db.inc
+ * pulls it in automatically), so this exercises it via footerbar.inc --
+ * one of the lightest pages that includes db.inc -- rather than calling it
+ * directly.
+ *
+ * @see session_setup.inc
+ */
+final class SessionSetupNullOrgLevelWarningTest extends \PHPUnit\Framework\TestCase {
+
+	public function testOrphanedStorytellerOrgDoesNotWarnAboutOrganizationLevel(): void {
+		$result = PageHarness::run(
+			'footerbar.inc',
+			session: [ 'user_id' => '42' ],
+			responses: [
+				[], // UserInfoDAO::readApprovalsDBInfo(42) -- empty, so getUserInfo() takes its no-ww_number fallback path
+				[], // UserInfoDAO::updateLastLoginDate(42) -- result unused
+				// getStorytellerOrganizations(42): one storyteller row whose organization_id (5)
+				// no longer matches a real organizations row -- the LEFT JOIN leaves every org
+				// column NULL/empty, so Organization::getLevel() returns null for it.
+				[ [
+					'chapter' => '', 'domain' => '', 'region' => '', 'nation' => '', 'globe' => '',
+					'organization_id' => '5', 'venue_id' => '0', 'assistant' => '0',
+				] ],
+				// Every query after this one (the admin-org-id lookup, the vss list query, the
+				// VST/org-storyteller position queries, and footerbar's own cam_number lookup)
+				// is left unqueued and gets an empty result automatically.
+			]
+		);
+
+		$this->assertStringNotContainsString( 'Attempt to read property "organization_level" on null', $result->stderr );
+	}
+}

--- a/tests/Integration/driver.php
+++ b/tests/Integration/driver.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Standalone child-process driver for PageHarness::run().
+ *
+ * Reads a JSON spec (argv[1]) describing $_GET/$_POST/$_SESSION and canned
+ * DB row responses, then includes the target application page under those
+ * conditions with include_path shadowing the real Database class (see
+ * stub_includes/include/Database.class.php) -- every other included file
+ * (db.inc, header.inc, DAOFactory, every DAO class) is the real, unmodified
+ * application code. Captures every query issued to the stub $db and, via a
+ * shutdown function (so it still fires if the page calls exit()/die() or
+ * hits a fatal error), writes them to the spec's outFile as JSON.
+ *
+ * Never run directly -- always invoked by PageHarness::run() as a php -d
+ * include_path=... child process with cwd set to the repo root.
+ */
+
+$specFile = $argv[1] ?? null;
+if ( !$specFile || !is_file( $specFile ) ) {
+    fwrite( STDERR, "driver.php: missing or unreadable spec file\n" );
+    exit( 2 );
+}
+$spec = json_decode( file_get_contents( $specFile ), true );
+if ( !is_array( $spec ) ) {
+    fwrite( STDERR, "driver.php: spec file did not contain valid JSON\n" );
+    exit( 2 );
+}
+
+$GLOBALS['__captured_queries'] = [];
+$GLOBALS['__stub_responses'] = $spec['responses'] ?? [];
+
+register_shutdown_function( function () use ( $spec ) {
+    $out = [
+        'queries' => $GLOBALS['__captured_queries'] ?? [],
+        'headers' => function_exists( 'headers_list' ) ? headers_list() : [],
+    ];
+    file_put_contents( $spec['outFile'], json_encode( $out ) );
+} );
+
+$_GET = $spec['get'] ?? [];
+$_POST = $spec['post'] ?? [];
+
+// Start the session ourselves first so real db.inc's own
+// `if (session_status() === PHP_SESSION_NONE) { session_start(); }` guard
+// sees an already-active session and skips re-starting it -- otherwise
+// CLI's session_start() would reset $_SESSION back to empty.
+session_start();
+$_SESSION = $spec['session'] ?? [];
+
+if ( !empty( $spec['ignoreLogin'] ) ) {
+    // header.inc's login gate is `!isset($_SESSION['user_id']) && !isset($IGNORE_LOGIN)`;
+    // setting this lets tests exercise pages that sit behind that gate without
+    // needing $_SESSION['user_id'] set (which would also pull in the much
+    // heavier session_setup.inc bootstrap via db.inc).
+    $GLOBALS['IGNORE_LOGIN'] = 1;
+}
+
+include getcwd() . '/' . $spec['page'];

--- a/tests/Integration/stub_includes/include/Database.class.php
+++ b/tests/Integration/stub_includes/include/Database.class.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Stub replacement for include/Database.class.php, used ONLY by the
+ * Integration test harness (tests/Integration/PageHarness.php) via PHP's
+ * include_path resolution: a bare `include_once("include/Database.class.php")`
+ * checks include_path before the calling script's own directory, so pointing
+ * php's -d include_path at this file's parent directory makes every real
+ * application file (db.inc, DAOFactory, every DAO class) transparently talk
+ * to this in-memory recorder instead of a real MySQL connection.
+ *
+ * Every query passed to Database::query() is appended to a global capture
+ * list (read back by the harness after the driver process exits) instead of
+ * being executed, and returns a canned row set popped from a global queue the
+ * driver script populates from the test's fixture file. No network I/O, no
+ * real settings.inc, no real mysqli extension calls.
+ */
+
+class Database {
+    public $db_host;
+    public $db_user;
+    public $db_pass;
+    public $db_name;
+    public $dbh;
+    public $lastResult;
+
+    public function __construct( $host = null, $user = null, $pass = null, $name = null ) {
+        $this->db_host = $host;
+        $this->db_user = $user;
+        $this->db_pass = $pass;
+        $this->db_name = $name;
+        $this->dbh = null;
+    }
+
+    /** Mirrors the real class's escape() shape; no real mysqli handle exists, so this is a plain fallback. */
+    function escape( $source ) {
+        return addslashes( (string)$source );
+    }
+
+    /**
+     * Records the query instead of running it, and returns the next canned
+     * row set queued for this connection (FIFO), defaulting to an empty
+     * result when the test didn't queue one for this call.
+     */
+    function query( string $query, array $params = [] ) {
+        $GLOBALS['__captured_queries'][] = [ 'sql' => $query, 'params' => $params, 'db' => $this->db_name ];
+        $rows = array_shift( $GLOBALS['__stub_responses'] ) ?? [];
+        $this->lastResult = new StubResultSet( $rows );
+        return $this->lastResult;
+    }
+
+    function throwError() {
+        // Real class echoes debug info then exit()s on a query failure.
+        // The stub never fails a query, so this should never be reached.
+        exit( 1 );
+    }
+
+    function getAllRows() { return $this->lastResult->getAllRows(); }
+    function getFieldCount() { return $this->lastResult->getFieldCount(); }
+    function getFieldNames() { return $this->lastResult->getFieldNames(); }
+    function nextRow() { return $this->lastResult->nextRow(); }
+    function numRows() { return $this->lastResult->numRows(); }
+    function affectedRows() { return $this->lastResult->affectedRows(); }
+    function getField( $field ) { return $this->lastResult->getField( $field ); }
+    function getInsertId() { return 1; }
+}
+
+/** Mirrors include/ResultSet.class.php's public interface over a plain PHP array of assoc rows -- no mysqli_result involved. */
+class StubResultSet {
+    private $rows;
+    private $currentRow = 0;
+
+    public function __construct( array $rows ) {
+        $this->rows = array_values( $rows );
+    }
+
+    function getFieldCount() { return count( $this->rows ) > 0 ? count( $this->rows[0] ) : 0; }
+    function getFieldNames() { return count( $this->rows ) > 0 ? array_keys( $this->rows[0] ) : []; }
+
+    function nextRow() {
+        if ( isset( $this->rows[$this->currentRow] ) ) {
+            return $this->rows[$this->currentRow++];
+        }
+        return array();
+    }
+
+    function numRows() { return count( $this->rows ); }
+    function affectedRows() { return 0; }
+    function getField( $field ) { return $this->rows[$this->currentRow][$field] ?? null; }
+    function getAllRows() { return $this->rows; }
+}

--- a/tests/Integration/stub_includes/include/settings.inc
+++ b/tests/Integration/stub_includes/include/settings.inc
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Stub replacement for include/settings.inc, used only by the Integration
+ * test harness via include_path shadowing (see stub_includes/include/Database.class.php
+ * for the mechanism). Values are dummy placeholders -- the stub Database
+ * class never actually connects to them.
+ */
+
+$SETTINGS = array();
+
+$SETTINGS["APPROVALS_SERVER"]   = "stub";
+$SETTINGS["APPROVALS_USERNAME"] = "stub";
+$SETTINGS["APPROVALS_PASSWORD"] = "stub";
+$SETTINGS["APPROVALS_DATABASE"] = "approvals_2017";
+
+$SETTINGS["PORTAL_SERVER"]      = "stub";
+$SETTINGS["PORTAL_USERNAME"]    = "stub";
+$SETTINGS["PORTAL_PASSWORD"]    = "stub";
+$SETTINGS["PORTAL_DATABASE"]    = "mes-portal";
+
+$SETTINGS["OAUTH_CLIENT_ID"]     = "stub";
+$SETTINGS["OAUTH_CLIENT_SECRET"] = "stub";
+$SETTINGS["OAUTH_REDIRECT_URI"]  = "https://example.test/oauth_callback.php";
+$SETTINGS["OAUTH_TOKEN_URL"]     = "https://example.test/oauth/v2/token";
+$SETTINGS["OAUTH_API_URL"]       = "https://example.test/api/authorized/user.json";
+
+$SETTINGS["EARLY_ACCESS_ENABLED"] = false;
+$SETTINGS["GOOGLE_MAP_SYNC_ENABLED"] = false;

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,21 +17,58 @@ tools\get-phpunit.ps1       # Windows PowerShell
 ## Running
 
 ```bash
-php tools/phpunit.phar                    # all suites (config: phpunit.xml)
-php tools/phpunit.phar --testsuite unit   # unit suite only
+php tools/phpunit.phar                          # all suites (config: phpunit.xml)
+php tools/phpunit.phar --testsuite unit         # unit suite only
+php tools/phpunit.phar --testsuite integration  # integration suite only
 ```
 
 ## Layout
 
 - `tests/Unit/` — fast, offline unit tests. They inject **stub doubles** for DAOs, so
   they need no database and never load `include/settings.inc`. See `tests/bootstrap.php`.
+  `tests/Unit/support/` holds shared test doubles (not test files themselves) — e.g.
+  `RecordingDb.php`, a stand-in `Database` that records every `query($sql, $params)`
+  call, used by the SQL-injection regression tests to assert a query uses `?`
+  placeholders and that a tainted value only ever appears in `$params`.
+- `tests/Integration/` — runs a real top-level page/include (not just a class) in an
+  **isolated child PHP process** via `PageHarness::run()`, against an in-memory stub
+  `Database` (`tests/Integration/stub_includes/`) — still fully offline, no real
+  database. This exists because many of this app's page scripts are top-level
+  procedural code that calls `header()`/`exit()` directly and reads `$_GET`/`$_POST`/
+  `$_SESSION` — not unit-testable in-process the way a class is. Process isolation
+  means an `exit()` inside the target page only ends that child process; a shutdown
+  function in the child still flushes captured queries even after a fatal error.
+  The mechanism: only `include/Database.class.php` and `include/settings.inc` are
+  shadowed via PHP's `include_path` (checked before a bare include's calling-script
+  directory) — the real `db.inc`, `header.inc`, `DAOFactory`, and every DAO class run
+  completely unmodified against the stub connection.
+  **Known gap:** any page that transitively includes `application.inc` (which
+  `require_once`s Smarty from a hardcoded absolute Linux path,
+  `/usr/share/php/smarty3/SmartyBC.class.php`) cannot run under this harness on a
+  machine without that exact path — absolute-path includes bypass `include_path`
+  shadowing entirely. Those pages currently rely on the manual QA steps in their
+  PR's test plan instead.
 - `tests/test_final_approval.php` — a pre-existing self-contained **live-DB integration**
   script (its own assert harness). Run directly: `php tests/test_final_approval.php`.
-  It is not part of the `unit` suite because it requires DB connectivity and fixtures.
+  It is not part of either suite because it requires DB connectivity and fixtures.
 
 ## Writing a unit test
 
 `require_once` the app file under test at the top (the bootstrap has already `chdir`'d to
 the repo root), then inject anonymous-class stubs for its collaborators. Example pattern:
 `tests/Unit/GetLowSTTest.php` constructs `ApplicationService` with four stub DAOs and asserts
-the resolved storyteller id for each `vss_id` branch.
+the resolved storyteller id for each `vss_id` branch. For a query-building test, use
+`tests/Unit/support/RecordingDb.php` instead of an ad hoc stub — see
+`tests/Unit/UserInfoDAOSqliTest.php` for the pattern.
+
+## Writing an integration (page-script) test
+
+`require_once 'tests/Integration/PageHarness.php'`, then call
+`PageHarness::run($page, get: [...], post: [...], session: [...], responses: [...])`
+and assert on the returned `PageHarnessResult` (`->queries`, `->sqlStatements()`,
+`->anyQueryContains()`, `->anyParamsContain()`, `->exitCode`). `ignoreLogin` defaults to
+`true`, bypassing `header.inc`'s login gate without needing `$_SESSION['user_id']` set
+(which would also trigger the heavier `session_setup.inc` bootstrap) — pass `false` only
+when specifically testing login-gate behavior. `responses` supplies one row-array per
+expected `$db->query()` call, in call order; a call beyond the queued responses gets an
+empty result. See `tests/Integration/FooterbarSqliTest.php` for the pattern.

--- a/tests/Unit/FilterRequiredApprovalWarningTest.php
+++ b/tests/Unit/FilterRequiredApprovalWarningTest.php
@@ -1,0 +1,38 @@
+<?php
+require_once 'classes/Filter.php';
+
+/**
+ * Regression test confirming Filter::mergeArray() doesn't warn when
+ * required_approval arrives as a scalar empty string (from a self-generated
+ * URL that flattened an empty array via implode()) rather than an array.
+ * Indexing [0] into that empty string used to trip PHP 8's "Uninitialized
+ * string offset 0" warning on nearly every sort-column click on
+ * app_main.php, since Filter::mergeArray() runs on every request there.
+ *
+ * PHPUnit's failOnWarning setting (phpunit.xml) means this test needs no
+ * explicit assertion on the warning itself -- a regression would fail the
+ * test outright.
+ *
+ * @see Filter::mergeArray()
+ */
+final class FilterRequiredApprovalWarningTest extends \PHPUnit\Framework\TestCase {
+
+	/** An empty-string required_approval (the real production shape) must not warn, and must not mark the filter as changed. */
+	public function testEmptyStringRequiredApprovalDoesNotWarn(): void {
+		$filter = new Filter();
+
+		$changed = $filter->mergeArray( [ 'required_approval' => '' ] );
+
+		$this->assertFalse( $changed );
+	}
+
+	/** A genuinely non-empty required_approval array is still applied correctly -- the fix doesn't just always fall back. */
+	public function testNonEmptyArrayRequiredApprovalIsApplied(): void {
+		$filter = new Filter();
+
+		$changed = $filter->mergeArray( [ 'required_approval' => [ 'Low', 'Mid' ] ] );
+
+		$this->assertTrue( $changed );
+		$this->assertSame( [ 'Low', 'Mid' ], $filter->required_approval );
+	}
+}

--- a/tests/Unit/UserInfoDAOGetPositionsWarningTest.php
+++ b/tests/Unit/UserInfoDAOGetPositionsWarningTest.php
@@ -1,0 +1,34 @@
+<?php
+require_once 'classes/UserInfoDAO.php';
+require_once 'tests/Unit/support/RecordingDb.php';
+
+/**
+ * Regression test confirming UserInfoDAO::getPositions() doesn't warn when
+ * getUserInfo() returns its early fallback array (no 'super_user' key) for a
+ * user with no ww_number on file -- e.g. a storyteller listed for a venue on
+ * MoveCharacter.php, which populates this DAO's cache via getUserInfo() for
+ * every storyteller_id it displays. Reading $userInfo['super_user'] directly
+ * used to trip an "Undefined array key" warning.
+ *
+ * PHPUnit's failOnWarning setting (phpunit.xml) means this test needs no
+ * explicit assertion on the warning itself -- a regression would fail the
+ * test outright.
+ *
+ * @see UserInfoDAO::getPositions()
+ * @see UserInfoDAO::getUserInfo()
+ */
+final class UserInfoDAOGetPositionsWarningTest extends \PHPUnit\Framework\TestCase {
+
+	public function testMissingSuperUserKeyDoesNotWarn(): void {
+		$db = new RecordingDb( [
+			[ [ 'ww_number' => '', 'name' => '' ] ], // readApprovalsDBInfo (inside getUserInfo): empty ww_number triggers the fallback array
+			[], // getVSTPositions
+			[], // getOrgSTPositions
+		] );
+		$dao = new UserInfoDAO( $db );
+
+		$positions = $dao->getPositions( 42 );
+
+		$this->assertSame( [], $positions );
+	}
+}

--- a/tests/Unit/support/RecordingDb.php
+++ b/tests/Unit/support/RecordingDb.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Minimal stand-in for the real Database class, shared by the SQL-injection
+ * regression tests: records every SQL string and bound params array passed
+ * to query(), and returns a canned row set (or none) so a test can assert
+ * the query text uses ?-placeholders and that a tainted value only ever
+ * appears in $params, never spliced into $sql.
+ *
+ * @see Database in include/Database.class.php, the real class this doubles for.
+ */
+class RecordingDb {
+	/** @var array<int, array{sql: string, params: array}> Every query() call, in order. */
+	public array $queries = [];
+
+	private array $responses;
+	private array $lastRows = [];
+	private int $cursor = 0;
+
+	/** @param array $responses One row-array per expected query() call, in call order (FIFO). A call beyond the queued responses gets no rows. */
+	public function __construct( array $responses = [] ) {
+		$this->responses = $responses;
+	}
+
+	public function query( string $sql, array $params = [] ) {
+		$this->queries[] = [ 'sql' => $sql, 'params' => $params ];
+		$this->lastRows = array_shift( $this->responses ) ?? [];
+		$this->cursor = 0;
+		return $this;
+	}
+
+	public function escape( $value ) {
+		return addslashes( (string)$value );
+	}
+
+	public function nextRow() {
+		if ( isset( $this->lastRows[ $this->cursor ] ) ) {
+			return $this->lastRows[ $this->cursor++ ];
+		}
+		return array();
+	}
+
+	public function numRows(): int {
+		return count( $this->lastRows );
+	}
+
+	public function getAllRows(): array {
+		return $this->lastRows;
+	}
+
+	/** The SQL text of every query() call, in order. */
+	public function sqlStatements(): array {
+		return array_column( $this->queries, 'sql' );
+	}
+}


### PR DESCRIPTION
## Summary
Five bug fixes merged earlier today (PRs #26–#29, plus the portal_user_cache collation fix in #25) shipped without regression tests. This PR retroactively adds them for the four that are testable in PHP (the collation fix is a pure DB schema change with no application logic to unit-test — it's already self-verifying via the before/after collation check in `utility/apply_portal_user_cache_collation_fix.php`):

- **`classes/Filter.php`**: `mergeArray()` no longer warns (`Uninitialized string offset 0`) when `required_approval` arrives as a scalar empty string instead of an array.
- **`classes/UserInfoDAO.php`**: `getPositions()` no longer warns (`Undefined array key "super_user"`) when `getUserInfo()` returns its no-`ww_number` fallback array.
- **`ModifyCharacterXPList1.php` / `ModifyCharacterList3.php`**: no longer warn (`Undefined array key "user_id"`) for an unauthenticated request reaching their own ownership check before `header.inc`'s login gate runs.
- **`ModifyCharacterXPList1.php` / `ModifyCharacterXPList3.php`**: XP log dates render as the stored calendar day instead of one day early (the `UNIX_TIMESTAMP()`-vs-PHP-timezone mismatch).
- **`MoveCharacter.php` / `session_setup.inc`**: no longer throw `Attempt to read property ... on null` when a session's `org_id` doesn't resolve to a real organization, or a storyteller's `organization_id` is orphaned.

Also adds the `tests/Integration/` harness (`PageHarness`) used by this PR and by the three open SQL-injection PRs (#52, #53, #54) — it runs a real top-level page script in an isolated child PHP process against an in-memory stub `Database`, so the real `db.inc`, `header.inc`, `DAOFactory`, and every DAO class run completely unmodified. See `tests/README.md`.

## Test plan
- [x] `php -l` on all new test files — no syntax errors
- [x] Verified genuine red/green for all 10 tests: reverted each target file to the commit immediately before its fix and confirmed the exact original warning/wrong date reproduces, then restored and confirmed green
- [x] Full suite: `php tools/phpunit.phar` → 35 tests, 44 assertions, green